### PR TITLE
Admin / User / Cannot delete user with status

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataStatus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataStatus.java
@@ -47,6 +47,8 @@ public interface IMetadataStatus {
      */
     boolean isUserMetadataStatus(int userId) throws Exception;
 
+    void transferMetadataStatusOwnership(int oldUserId, int newUserId) throws Exception;
+
     /**
      * If groupOwner match regular expression defined in setting metadata/workflow/draftWhenInGroup, then set status to draft to enable
      * workflow.

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataStatus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataStatus.java
@@ -71,6 +71,15 @@ public class BaseMetadataStatus implements IMetadataStatus {
         return metadataStatusRepository.count(MetadataStatusSpecs.hasUserId(userId)) > 0;
     }
 
+    @Override
+    public void transferMetadataStatusOwnership(int oldUserId, int newUserId) throws Exception {
+        List<MetadataStatus> oldUserStatus = metadataStatusRepository.findAll(MetadataStatusSpecs.hasUserId(oldUserId));
+        oldUserStatus.stream().forEach(s -> {
+            s.setUserId(newUserId);
+        });
+        metadataStatusRepository.saveAll(oldUserStatus);
+    }
+
     /**
      * Return last workflow status for the metadata id
      */

--- a/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
@@ -43,6 +43,7 @@ import org.fao.geonet.domain.*;
 import org.fao.geonet.exceptions.UserNotFoundEx;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.datamanager.base.BaseMetadataStatus;
 import org.fao.geonet.kernel.security.SecurityProviderConfiguration;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.repository.*;
@@ -97,6 +98,9 @@ public class UsersApi {
 
     @Autowired
     UserGroupRepository userGroupRepository;
+
+    @Autowired
+    BaseMetadataStatus baseMetadataStatus;
 
     @Autowired
     UserSavedSelectionRepository userSavedSelectionRepository;
@@ -326,8 +330,14 @@ public class UsersApi {
         }
 
         if (dataManager.isUserMetadataStatus(userIdentifier)) {
-            throw new IllegalArgumentException(
-                "Cannot delete a user that has set a metadata status");
+            Optional<User> nobody = userRepository.findById(0);
+            if (nobody.isPresent()) {
+                baseMetadataStatus.transferMetadataStatusOwnership(userIdentifier,
+                    nobody.get().getId());
+            } else {
+              throw new IllegalArgumentException(
+                "Cannot delete a user that has set a metadata status. Check in database to transfer those status to another user or create a user nobody with id = 0.");
+            }
         }
 
         userGroupRepository.deleteAllByIdAttribute(UserGroupId_.userId,

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -713,6 +713,10 @@ INSERT INTO HarvesterSettings (id, parentid, name, value) VALUES  (1,NULL,'harve
 -- === Table: Users
 -- ======================================================================
 
+INSERT INTO Users (id, username, password, name, surname, profile, kind, organisation, security, authtype, isenabled) VALUES  (0,'nobody','','nobody','nobody',4,'','','','', 'n');
+INSERT INTO Address (id, address, city, country, state, zip) VALUES  (0, '', '', '', '', '');
+INSERT INTO UserAddress (userid, addressid) VALUES  (0, 0);
+
 INSERT INTO Users (id, username, password, name, surname, profile, kind, organisation, security, authtype, isenabled) VALUES  (1,'admin','46e44386069f7cf0d4f2a420b9a2383a612f316e2024b0fe84052b0b96c479a23e8a0be8b90fb8c2','admin','admin',0,'','','','', 'y');
 INSERT INTO Address (id, address, city, country, state, zip) VALUES  (1, '', '', '', '', '');
 INSERT INTO UserAddress (userid, addressid) VALUES  (1, 1);

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v406/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v406/migrate-default.sql
@@ -1,4 +1,8 @@
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/remotevalidation/nodeid', '', 0, 7212, 'n');
 
+INSERT INTO Users (id, username, password, name, surname, profile, kind, organisation, security, authtype, isenabled) VALUES  (0,'nobody','','nobody','nobody',4,'','','','', 'n');
+INSERT INTO Address (id, address, city, country, state, zip) VALUES  (0, '', '', '', '', '');
+INSERT INTO UserAddress (userid, addressid) VALUES  (0, 0);
+
 UPDATE Settings SET value='4.0.6' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';


### PR DESCRIPTION
When user set metadata status it is associated with them (even if there is no FK
in db). The Java app is checking this and there is no way to drop the
user.

Add a user nobody with id=0 that we can use to assign when removing a
user.

Add more details for end-users about how to solve this type of error.

After this change, events get assigned to the user nobody

![image](https://user-images.githubusercontent.com/1701393/130816203-99858aa7-63d9-464a-999d-49acb72a3dce.png)
