### PR TITLE
Search / Match all docs

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -434,7 +434,7 @@ public class EsHTTPProxy {
 
         // If admin you can see all
         if (Profile.Administrator.equals(userSession.getProfile())) {
-            return "*";
+            return "*:*";
         } else {
             // op0 (ie. view operation) contains one of the ids of your groups
             Set<Integer> groups = accessManager.getUserGroups(userSession, context.getIpAddress(), false);


### PR DESCRIPTION
any (the default field) might be empty for records with indexing errors and will not be returned in some searches.