### PR TITLE
Formatter / Avoid JS error when property does not exist in object

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -345,6 +345,9 @@
 
           var getObjectValueByPath = function(obj, path){
             for (var i = 0, path = path.split('.'), len = path.length; i < len; i++){
+              if (angular.isUndefined(obj)) {
+                return undefined;
+              }
               obj = obj[path[i]];
             };
             return obj;


### PR DESCRIPTION
Eg. in a dublin core record, standardName does not exist.