### PR TITLE
Harvester / CSW / Preserve order when processing records

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
@@ -25,13 +25,7 @@ package org.fao.geonet.kernel.harvest.harvester.csw;
 
 import java.net.URL;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.collect.ImmutableSet;
@@ -289,7 +283,7 @@ class Harvester implements IHarvester<HarvestResult> {
             int foundCnt = 0;
 
             log.debug("Extracting all elements in the csw harvesting response");
-            Set<RecordInfo> records = new HashSet<RecordInfo>();
+            Set<RecordInfo> records = new LinkedHashSet<RecordInfo>();
             for (Element record : list) {
                 try {
                     RecordInfo recInfo = getRecordInfo((Element) record.clone());


### PR DESCRIPTION
Make easier to track down which records may trigger errors.
If GetRecords use sortBy, also preserved order in the reocrds in current page. Log will also follow that order. 

Follow up of https://github.com/titellus/core-geonetwork/pull/14