### PR TITLE
Search / Facet usually do not reload if selected (the time they are selected)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -55,7 +55,7 @@
 
         var lastFacet = this.lastUpdatedFacet
 
-        if (this._isFlatTermsFacet(lastFacet) && this.searchCtrl.hasFiltersForKey(lastFacet.path[0])) {
+        if (this._isNotNestedFacet(lastFacet) && this.searchCtrl.hasFiltersForKey(lastFacet.path[0])) {
           this.list.forEach(function (f) {
             if (f.key === lastFacet.key) {
               f.items = lastFacet.items
@@ -148,8 +148,8 @@
   };
 
 
-  FacetsController.prototype._isFlatTermsFacet = function (facet) {
-    return facet && (facet.type === 'terms') && !facet.aggs
+  FacetsController.prototype._isNotNestedFacet = function (facet) {
+    return facet && (facet.type === 'terms' || facet.type === 'tree') && !facet.aggs
   }
 
   FacetsController.$inject = [
@@ -272,6 +272,7 @@
         value = '-('+value+')';
       }
     } else if (facet.type === 'tree') {
+      this.facetsCtrl.lastUpdatedFacet = facet;
     }
     this.searchCtrl.updateState(item.path, value);
   }

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -55,7 +55,7 @@
 
         var lastFacet = this.lastUpdatedFacet
 
-        if (this._isFlatTermsFacet(lastFacet) && this.searchCtrl.hasFiltersForKey(lastFacet.key)) {
+        if (this._isFlatTermsFacet(lastFacet) && this.searchCtrl.hasFiltersForKey(lastFacet.path[0])) {
           this.list.forEach(function (f) {
             if (f.key === lastFacet.key) {
               f.items = lastFacet.items


### PR DESCRIPTION
But the facet key is not necessarily the search field. It can be a `meta.field` which define a specific search field or can be `terms.field` in case of terms aggs...

So it is probably safer to check the first element in the path which is the name of the field to search on.

Then if user select another facet, then others are reload. We have a distinction with the `lastUpdatedFacet`