### PR TITLE
Search / Facet / Fix highlight class

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
@@ -31,7 +31,6 @@
                   (facet.dates && facet.dates.length > 0))"
          class="gn-facet">
       <a href
-        title="::{{facet.key | translate}}"
         class="gn-facet-header flex-row width-100"
         ng-class="{'gn-facet-panel-active': ctrl.searchCtrl.isInSearch(facet.path)}"
         gn-collapsible="::ctrl.fLvlCollapse[facet.key]">

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
@@ -33,7 +33,7 @@
       <a href
         title="::{{facet.key | translate}}"
         class="gn-facet-header flex-row width-100"
-        ng-class="{'gn-facet-panel-active': ctrl.searchCtrl.isInSearch([facet.key])}"
+        ng-class="{'gn-facet-panel-active': ctrl.searchCtrl.isInSearch(facet.path)}"
         gn-collapsible="::ctrl.fLvlCollapse[facet.key]">
         <span class="flex-shrink text-ellipsis">{{('facet-' + facet.key) | facetKeyTranslator}}</span>
         <span class="fa fa-fw"


### PR DESCRIPTION
Aggregation key is not the same as the search path.

eg.

```
  "test": {
    "terms": {
      "field": "cl_spatialRepresentationType.key",
      "size": 10
    }, "meta": {
        "field": "cl_spatialRepresentationType.key"
    }
  },
```
Should be highlighted when selected like others.

![image](https://user-images.githubusercontent.com/1701393/132802887-76c634b0-66ec-4989-a096-225a9a8ac82d.png)
