### PR TITLE
API / Attachements / Do not allow file upload with '..'

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -192,6 +192,7 @@ public class FilesystemStore extends AbstractStore {
                                         final InputStream is, @Nullable final Date changeDate, final MetadataResourceVisibility visibility,
                                         Boolean approved) throws Exception {
         int metadataId = canEdit(context, metadataUuid, approved);
+        checkResourceId(filename);
         Path filePath = getPath(context, metadataId, visibility, filename, approved);
         Files.copy(is, filePath, StandardCopyOption.REPLACE_EXISTING);
         if (changeDate != null) {


### PR DESCRIPTION
If a user try to import a record with '..' eg. afilewithdoubledot..JPG then the record is somehow broken.

The attachement API does not allow to GET/DELETE it:
```
<apiError>
<code>forbidden</code>
<description>Invalid resource identifier 'afilewithdoubledot..JPG'.</description>
```

And MEF export, DELETE API fails to create a ZIP of that record:

```
2021-09-16 16:51:43,848 ERROR [geonetwork] - Backup record. Error: Invalid resource identifier 'afilewithdoubledot..JPG'.
```

Only option is to go to the data directory and remove the attachement or run a DELETE on the record with http://localhost:8080/geonetwork/srv/api/records/21501?withBackup=false


Add the same file check on PUT operation to avoid that situation.