### PR TITLE
Dublin core / When not flat eg. advanced view, all elements can be removed in DC.

### DIFF
--- a/schemas/dublin-core/src/main/plugin/dublin-core/layout/config-editor.xml
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/layout/config-editor.xml
@@ -63,7 +63,7 @@
         <for name="dc:subject"/>
       </flatModeExceptions>
     </view>
-    <view name="advanced">
+    <view name="advanced" upAndDownControlHidden="true">
       <sidePanel>
         <directive data-gn-validation-report=""/>
         <directive data-gn-onlinesrc-list=""/>

--- a/schemas/dublin-core/src/main/plugin/dublin-core/layout/layout.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/layout/layout.xsl
@@ -136,10 +136,38 @@
       <!--<xsl:with-param name="attributesSnippet" as="node()"/>-->
       <xsl:with-param name="type" select="gn-fn-metadata:getFieldType($editorConfig, name(), '', $xpath)"/>
       <xsl:with-param name="name" select="if ($isEditing) then gn:element/@ref else ''"/>
-      <xsl:with-param name="editInfo"
-                      select="gn:element"/>
-      <xsl:with-param name="parentEditInfo"
-                      select="if ($added) then $container/gn:element else element()"/>
+      <xsl:with-param name="editInfo" as="node()">
+        <xsl:choose>
+          <xsl:when test="$isFlatMode">
+            <xsl:copy-of select="gn:element"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <!-- When not flat eg. advanced view, all elements can be removed in DC. -->
+            <gn:element ref="{gn:element/@ref}"
+                        parent="{gn:element/@parent}"
+                        uuid="{gn:element/@uuid}"
+                        del="true"
+                        min="0"
+                        max="{gn:element/@max}"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:with-param>
+      <xsl:with-param name="parentEditInfo" as="node()">
+        <xsl:choose>
+          <xsl:when test="$added"><xsl:copy-of select="$container/gn:element"/></xsl:when>
+          <xsl:when test="$isFlatMode">
+            <xsl:copy-of select="gn:element"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <gn:element ref="{gn:element/@ref}"
+                        parent="{gn:element/@parent}"
+                        uuid="{gn:element/@uuid}"
+                        del="true"
+                        min="0"
+                        max="{gn:element/@max}"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:with-param>
       <xsl:with-param name="listOfValues" select="$helper"/>
       <!-- When adding an element, the element container contains
       information about cardinality. -->

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -1386,6 +1386,7 @@
     <xsl:param name="editInfo"/>
     <xsl:param name="parentEditInfo" required="no"/>
     <xsl:param name="isRequired" required="no"/>
+
     <xsl:if
       test="(($parentEditInfo and (
               $parentEditInfo/@del = 'true' or


### PR DESCRIPTION


Dublin core is a choice of 0..n of any elements. So XSD contains no real indication about element cardinality.

![image](https://user-images.githubusercontent.com/1701393/134012811-028c7a3f-af14-4500-86d3-84ac9edd86a2.png)

Hide up control when adding an object. DC does not support it. 