### PR TITLE
Build / Warning fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -676,11 +676,6 @@
         <version>${geotools.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.geotools.xsd</groupId>
-        <artifactId>gt-xsd-fes</artifactId>
-        <version>${geotools.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.geotools</groupId>
         <artifactId>gt-epsg-extension</artifactId>
         <version>${geotools.version}</version>


### PR DESCRIPTION
```
 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.geotools.xsd:gt-xsd-fes:jar -> duplicate declaration of version ${geotools.version} @ org.geonetwork-opensource:geonetwork:4.0.6-SNAPSHOT, /home/app/core-geonetwork/pom.xml, line 678, column 19
```