### PR TITLE
Dublin core / Adding element has no label

### DIFF
--- a/schemas/dublin-core/src/main/plugin/dublin-core/layout/layout.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/layout/layout.xsl
@@ -172,10 +172,7 @@
       <!-- When adding an element, the element container contains
       information about cardinality. -->
       <xsl:with-param name="isFirst"
-                      select="if ($added) then
-                      (($container/gn:element/@down = 'true' and not($container/gn:element/@up)) or
-                      (not($container/gn:element/@down) and not($container/gn:element/@up)))
-                      else
+                      select="if ($added) then true() else
                       ((gn:element/@down = 'true' and not(gn:element/@up)) or
                       (not(gn:element/@down) and not(gn:element/@up)))"/>
     </xsl:call-template>


### PR DESCRIPTION
In dublin core, we can add an existing element with "+" action and the label of the first element is displayed so user knows what has been added.
But if adding a new element from the choice list, then no label is displayed on the added element.

Always display the label when adding a new element (as we don't have indication if we are adding another existing element or a new one).

Editor refresh will only show labels on the first one.