### PR TITLE
Admin / Thesaurus / Improve thesaurus origin and type

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/ThesaurusType.java
+++ b/core/src/main/java/org/fao/geonet/kernel/ThesaurusType.java
@@ -1,0 +1,28 @@
+//===	Copyright (C) 2001-2021 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package org.fao.geonet.kernel;
+
+public enum ThesaurusType {
+    external,
+    local
+}

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -47,10 +47,7 @@ import org.fao.geonet.api.exception.WebApplicationException;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.kernel.GeonetworkDataDirectory;
-import org.fao.geonet.kernel.KeywordBean;
-import org.fao.geonet.kernel.Thesaurus;
-import org.fao.geonet.kernel.ThesaurusManager;
+import org.fao.geonet.kernel.*;
 import org.fao.geonet.kernel.search.KeywordsSearcher;
 import org.fao.geonet.kernel.search.keyword.*;
 import org.fao.geonet.kernel.setting.SettingManager;
@@ -488,6 +485,7 @@ public class KeywordsApi {
 
         }
 
+
         if (isJson) {
             return jsonResponse;
         } else {
@@ -664,7 +662,7 @@ public class KeywordsApi {
         @Parameter(
             description = "Local or external (default).")
         @RequestParam(value = "type", defaultValue = "external")
-            String type,
+            ThesaurusType type,
         @Parameter(
             description = "Type of thesaurus, usually one of the ISO thesaurus type codelist value. Default is theme.")
         @RequestParam(value = "dir", defaultValue = "theme")
@@ -730,7 +728,7 @@ public class KeywordsApi {
 
                 // Rename .xml to .rdf for all thesaurus
                 fname = fname.replace(extension, "rdf");
-                uploadThesaurus(rdfFile, stylesheet, context, fname, type, dir);
+                uploadThesaurus(rdfFile, stylesheet, context, fname, type.toString(), dir);
             } else {
                 Log.debug(Geonet.THESAURUS, "Incorrect extension for thesaurus named: " + fname);
                 throw new Exception("Incorrect extension for thesaurus named: "
@@ -779,7 +777,7 @@ public class KeywordsApi {
         @Parameter(
             description = "Local or external (default).")
         @RequestParam(value = "type", defaultValue = "external")
-            String type,
+            ThesaurusType type,
         @Parameter(
             description = "Type of thesaurus, usually one of the ISO thesaurus type codelist value. Default is theme.")
         @RequestParam(value = "dir", defaultValue = "theme")
@@ -884,7 +882,7 @@ public class KeywordsApi {
                 xmlOutput.output(element,
                     new OutputStreamWriter(new FileOutputStream(rdfFile.toFile().getCanonicalPath()),
                         StandardCharsets.UTF_8));
-                uploadThesaurus(rdfFile, "_none_", context, fname, type, dir);
+                uploadThesaurus(rdfFile, "_none_", context, fname, type.toString(), dir);
                 response.setStatus(HttpServletResponse.SC_CREATED);
             } else {
                 response.addHeader("Content-Disposition", "inline; filename=\"" + fname + "\"");
@@ -1103,7 +1101,7 @@ public class KeywordsApi {
         @Parameter(
             description = "Local or external (default).")
         @RequestParam(value = "type", defaultValue = "external")
-            String type,
+            ThesaurusType type,
         @Parameter(
             description = "Type of thesaurus, usually one of the ISO thesaurus type codelist value. Default is theme.")
         @RequestParam(value = "dir", defaultValue = "theme")
@@ -1184,7 +1182,7 @@ public class KeywordsApi {
 
             // Rename .xml to .rdf for all thesaurus
             fname = fname.replace(extension, "rdf");
-            uploadThesaurus(rdfFile, stylesheet, context, fname, type, dir);
+            uploadThesaurus(rdfFile, stylesheet, context, fname, type.toString(), dir);
         } else {
             Log.debug(Geonet.THESAURUS, "Incorrect extension for thesaurus named: " + fname);
             throw new MissingServletRequestParameterException("Incorrect extension for thesaurus", fname);

--- a/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
@@ -78,6 +78,7 @@
        * The list of thesaurus
        */
       $scope.thesaurus = [];
+      $scope.thesaurusTypes = ['external', 'local'];
       /**
        * The currently selected thesaurus
        */
@@ -208,13 +209,41 @@
         }
       };
 
+      $scope.thesaurusTypeBySchema = [];
+      function loadKeywordTypeForSchema(schema) {
+        var url = '../api/standards/'
+          + schema.id + '/codelists/'
+          + schema.ns + ':MD_KeywordTypeCode';
+        $http.get(url, {cache: true}).then(function(r) {
+          angular.forEach(r.data, function(o, k) {
+            $scope.thesaurusTypeBySchema.push({
+              schema: schema.id,
+              key: k,
+              label: o
+            });
+          })
+        });
+      }
+      function loadKeywordTypeCodes() {
+        var schemas = [
+          {id: 'iso19139', ns: 'gmd'},
+          {id: 'iso19115-3.2018', ns: 'mri'}];
+        $scope.thesaurusTypeBySchema = [];
+        for (var i = 0; i < schemas.length; i ++) {
+          loadKeywordTypeForSchema(schemas[i]);
+        }
+      }
+
       /**
        * Add a new local thesaurus and open the modal
        */
       $scope.addThesaurus = function(type) {
         creatingThesaurus = true;
 
+        loadKeywordTypeCodes();
+
         $scope.thesaurusImportType = 'theme';
+        $scope.thesaurusImportOrigin = $scope.thesaurusTypes[0];
         $scope.importAs = type;
         $scope.thesaurusSelected = {
           title: '',

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -246,5 +246,6 @@
   "cite.format.ris": "RIS",
   "cite.format.ris.help": "Tag format developed by Research Information Systems.",
   "cite.format.bibtex": "BibTex",
-  "cite.format.bibtex.help": "A BibTeX database file is formed by a list of entries, with each entry corresponding to a bibliographical item."
+  "cite.format.bibtex.help": "A BibTeX database file is formed by a list of entries, with each entry corresponding to a bibliographical item.",
+  "origin": "Origin"
 }

--- a/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
@@ -323,13 +323,30 @@
             <!-- Registry selection -->
             <div data-ng-show="importAs == 'registry'"
                  data-gn-registry-browser="thesaurusUrl"/>
-
             <br/>
-            <div
-              data-schema-info-combo="codelist"
-              data-selected-info="thesaurusImportType"
-              data-gn-schema-info="gmd:MD_KeywordTypeCode"
-              lang="lang"></div>
+
+            <label class="control-label">
+              <span data-translate="">thesaurusClass</span>
+              <select class="form-control"
+                      ng_model="thesaurusImportType"
+                      ng-options="o.key as o.label group by o.schema
+                                  for (k, o) in thesaurusTypeBySchema "/>
+            </label>
+            <br/>
+
+            <label class="control-label"
+                   data-ng-show="importAs != 'registry'">
+              <span data-translate="">origin</span>
+              <select class="form-control"
+                      name="type"
+                      data-ng-model="thesaurusImportOrigin">
+                <option data-ng-repeat="o in thesaurusTypes"
+                        value="{{o}}">{{o}}</option>
+              </select>
+            </label>
+
+
+
             <input type="text" class="hidden" name="dir" data-ng-model="thesaurusImportType"/>
             <ul>
               <li data-ng-repeat="file in queue">{{file.name}} ({{file.type}} / {{file.size}} KB) <i


### PR DESCRIPTION
* Restrict thesaurus origin to external and local. Using other value (which was allowed by the API) can completely break the thesaurus manager.
* Add option to load by file upload or by URL a local thesaurus (registry are always external)

![image](https://user-images.githubusercontent.com/1701393/135995598-0a56f9a5-5802-435f-a03a-3a71f6781cf7.png)


* Add thesaurus type allowed by ISO19115-3

![image](https://user-images.githubusercontent.com/1701393/135995613-210ab9e4-f49c-403c-85d5-cc242f7694a8.png)
