### PR TITLE
Indexing / Thesaurus / Make field name more consistent.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -583,18 +583,8 @@
                                   cit:identifier/mcc:MD_Identifier/
                                     mcc:code/(gco:CharacterString|gcx:Anchor)/text())"/>
 
-          <xsl:variable name="key">
-            <xsl:choose>
-              <xsl:when test="$thesaurusId != ''">
-                <xsl:value-of select="tokenize($thesaurusId, '\.')[last()]"/>
-              </xsl:when>
-              <!-- Try to build a thesaurus key based on the name
-              by removing space - to be improved. -->
-              <xsl:when test="normalize-space($thesaurusName) != ''">
-                <xsl:value-of select="replace($thesaurusName, '[^a-zA-Z0-9]', '')"/>
-              </xsl:when>
-            </xsl:choose>
-          </xsl:variable>
+          <xsl:variable name="key"
+                        select="gn-fn-index:build-thesaurus-index-field-name($thesaurusId, $thesaurusName)"/>
 
           <xsl:if test="normalize-space($key) != ''">
             <xsl:variable name="keywords"
@@ -619,28 +609,15 @@
                           select="current-grouping-key()"/>
 
             <xsl:variable name="thesaurusId"
-                          select="normalize-space(mri:thesaurusName/*/
-                                    cit:identifier[position() = 1]/*/
-                                      cit:code/(gco:CharacterString|gcx:Anchor)/text())"/>
+                          select="normalize-space(mri:thesaurusName/cit:CI_Citation/
+                                  cit:identifier/mcc:MD_Identifier/
+                                    mcc:code/(gco:CharacterString|gcx:Anchor)/text())"/>
 
-            <xsl:variable name="key">
-              <xsl:choose>
-                <xsl:when test="$thesaurusId != ''">
-                  <xsl:value-of select="$thesaurusId"/>
-                </xsl:when>
-                <!-- Try to build a thesaurus key based on the name
-                by removing space - to be improved. -->
-                <xsl:when test="normalize-space($thesaurusName) != ''">
-                  <xsl:value-of select="replace($thesaurusName, ' ', '-')"/>
-                </xsl:when>
-              </xsl:choose>
-            </xsl:variable>
+            <xsl:variable name="key"
+                          select="gn-fn-index:build-thesaurus-index-field-name($thesaurusId, $thesaurusName)"/>
 
             <xsl:if test="normalize-space($key) != ''">
-              <xsl:variable name="thesaurusField"
-                            select="replace($key, '[^a-zA-Z0-9]', '')"/>
-
-              "<xsl:value-of select="$thesaurusField"/>": {
+              "<xsl:value-of select="$key"/>": {
               "id": "<xsl:value-of select="gn-fn-index:json-escape($thesaurusId)"/>",
               "title": "<xsl:value-of select="gn-fn-index:json-escape($thesaurusName)"/>",
               "theme": "<xsl:value-of select="gn-fn-index:json-escape(mri:type/*/@codeListValue)"/>",

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -559,18 +559,8 @@
                                   gmd:identifier[position() = 1]/gmd:MD_Identifier/
                                     gmd:code/(gco:CharacterString|gmx:Anchor)/text())"/>
 
-          <xsl:variable name="key">
-            <xsl:choose>
-              <xsl:when test="$thesaurusId != ''">
-                <xsl:value-of select="tokenize($thesaurusId, '\.')[last()]"/>
-              </xsl:when>
-              <!-- Try to build a thesaurus key based on the name
-              by removing space - to be improved. -->
-              <xsl:when test="normalize-space($thesaurusName) != ''">
-                <xsl:value-of select="replace($thesaurusName, ' ', '-')"/>
-              </xsl:when>
-            </xsl:choose>
-          </xsl:variable>
+          <xsl:variable name="key"
+                        select="gn-fn-index:build-thesaurus-index-field-name($thesaurusId, $thesaurusName)"/>
 
           <xsl:if test="normalize-space($key) != ''">
             <xsl:variable name="keywords"
@@ -599,24 +589,11 @@
                                     gmd:identifier[position() = 1]/gmd:MD_Identifier/
                                       gmd:code/(gco:CharacterString|gmx:Anchor)/text())"/>
 
-            <xsl:variable name="key">
-              <xsl:choose>
-                <xsl:when test="$thesaurusId != ''">
-                  <xsl:value-of select="$thesaurusId"/>
-                </xsl:when>
-                <!-- Try to build a thesaurus key based on the name
-                by removing space - to be improved. -->
-                <xsl:when test="normalize-space($thesaurusName) != ''">
-                  <xsl:value-of select="replace($thesaurusName, ' ', '-')"/>
-                </xsl:when>
-              </xsl:choose>
-            </xsl:variable>
+            <xsl:variable name="key"
+                          select="gn-fn-index:build-thesaurus-index-field-name($thesaurusId, $thesaurusName)"/>
 
             <xsl:if test="normalize-space($key) != ''">
-              <xsl:variable name="thesaurusField"
-                            select="replace($key, '[^a-zA-Z0-9]', '')"/>
-
-              "<xsl:value-of select="$thesaurusField"/>": {
+              "<xsl:value-of select="$key"/>": {
                 "id": "<xsl:value-of select="gn-fn-index:json-escape($thesaurusId)"/>",
                 "title": "<xsl:value-of select="gn-fn-index:json-escape($thesaurusName)"/>",
                 "theme": "<xsl:value-of select="gn-fn-index:json-escape(gmd:type/*/@codeListValue)"/>",

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -452,7 +452,7 @@
     </xsl:variable>
 
     <xsl:variable name="keyWithoutDot"
-                  select="replace($key, '\\.', '-')"/>
+                  select="replace($key, '\.', '-')"/>
 
     <xsl:value-of select="concat('th_', replace($keyWithoutDot, '[^a-zA-Z0-9_-]', ''))"/>
   </xsl:function>

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -429,6 +429,35 @@
   </xsl:template>
 
 
+  <!-- Produce a thesaurus field name valid in an XML document
+  and as an Elasticsearch field name. -->
+  <xsl:function name="gn-fn-index:build-thesaurus-index-field-name">
+    <xsl:param name="thesaurusId" as="xs:string?"/>
+    <xsl:param name="thesaurusName" as="xs:string?"/>
+
+    <xsl:variable name="key">
+      <xsl:choose>
+        <xsl:when test="starts-with($thesaurusId, 'geonetwork.thesaurus')">
+          <!-- eg. geonetwork.thesaurus.local.theme.dcsmm.area = dcsmm.area-->
+          <xsl:value-of select="string-join(
+                                  tokenize($thesaurusId, '\.')[position() > 4], '.')"/>
+        </xsl:when>
+        <xsl:when test="normalize-space($thesaurusId) != ''">
+          <xsl:value-of select="normalize-space($thesaurusId)"/>
+        </xsl:when>
+        <xsl:when test="normalize-space($thesaurusName) != ''">
+          <xsl:value-of select="replace(normalize-unicode($thesaurusName, 'NFKD'), '\P{IsBasicLatin}', '')"/>
+        </xsl:when>
+      </xsl:choose>
+    </xsl:variable>
+
+    <xsl:variable name="keyWithoutDot"
+                  select="replace($key, '\\.', '-')"/>
+
+    <xsl:value-of select="concat('th_', replace($keyWithoutDot, '[^a-zA-Z0-9_-]', ''))"/>
+  </xsl:function>
+
+
   <xsl:template name="build-thesaurus-fields">
     <xsl:param name="thesaurus" as="xs:string"/>
     <xsl:param name="thesaurusId" as="xs:string"/>
@@ -439,15 +468,13 @@
     <!-- Index keyword characterString including multilingual ones
      and element like gmx:Anchor including the href attribute
      which may contains keyword identifier. -->
-    <xsl:variable name="thesaurusField"
-                  select="concat('th_', replace($thesaurus, '[^a-zA-Z0-9-_]', ''))"/>
 
-    <xsl:element name="{$thesaurusField}Number">
+    <xsl:element name="{$thesaurus}Number">
       <xsl:value-of select="count($keywords)"/>
     </xsl:element>
 
     <xsl:if test="count($keywords) > 0">
-      <xsl:element name="{$thesaurusField}">
+      <xsl:element name="{$thesaurus}">
         <xsl:attribute name="type" select="'object'"/>
         [<xsl:for-each select="$keywords">
         <xsl:variable name="uri"
@@ -533,7 +560,7 @@
 
 
       <xsl:if test="count($thesaurusTree/*) > 0">
-        <xsl:element name="{$thesaurusField}_tree">
+        <xsl:element name="{$thesaurus}_tree">
           <xsl:attribute name="type" select="'object'"/>{
           <xsl:variable name="defaults"
                         select="distinct-values($thesaurusTree/default)"/>


### PR DESCRIPTION
* We use to keep last part of the identifier after the last '.' but some thesaurus file contains dot, so preserve full file name. '.' is replace by '-' to build valid Elasticsearch field name.
* Better handle funny names or identifier with special character (convert to ASCII characters). Avoid error building valid qname for XML document
* Use same rules everywhere in ISO19139, ISO19115-3 and th_* fields or allThesaurus fields.

![image](https://user-images.githubusercontent.com/1701393/137481525-b878f22f-2ebd-442c-bd9c-0b575d3daa3c.png)


Catalogue using thesaurus with '.' are affected and will need to update facet name.