### PR TITLE
API / Processes / Search and replace with database

### DIFF
--- a/domain/src/main/java/org/fao/geonet/repository/MetadataRepository.java
+++ b/domain/src/main/java/org/fao/geonet/repository/MetadataRepository.java
@@ -32,6 +32,7 @@ import org.fao.geonet.domain.Metadata;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -74,4 +75,31 @@ public interface MetadataRepository extends GeonetRepository<Metadata, Integer>,
      */
     @Nonnull
     List<Metadata> findAllByHarvestInfo_Uuid(@Nonnull String uuid);
+
+
+
+    @Query(value = "SELECT replace(data, :search, :replace) FROM metadata m " +
+        "WHERE uuid = :uuid",
+        nativeQuery = true)
+    String selectOneWithSearchAndReplace(
+        @Param("uuid") String uuid,
+        @Param("search") String search,
+        @Param("replace") String replace);
+
+    @Query(value = "SELECT regexp_replace(data, :pattern, :replace) FROM metadata m " +
+        "WHERE uuid = :uuid",
+        nativeQuery = true)
+    String selectOneWithRegexSearchAndReplace(
+        @Param("uuid") String uuid,
+        @Param("pattern") String search,
+        @Param("replace") String replace);
+
+    @Query(value = "SELECT regexp_replace(data, :pattern, :replace, :flags) FROM metadata m " +
+        "WHERE uuid = :uuid",
+        nativeQuery = true)
+    String selectOneWithRegexSearchAndReplaceWithFlags(
+        @Param("uuid") String uuid,
+        @Param("pattern") String search,
+        @Param("replace") String replace,
+        @Param("flags") String flags);
 }

--- a/services/src/main/java/org/fao/geonet/api/processing/DatabaseProcessApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/DatabaseProcessApi.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.api.processing;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
+import jeeves.services.ReadWriteController;
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.api.ApiParams;
+import org.fao.geonet.api.ApiUtils;
+import org.fao.geonet.api.processing.report.MetadataReplacementProcessingReport;
+import org.fao.geonet.api.processing.report.XsltMetadataProcessingReport;
+import org.fao.geonet.events.history.RecordProcessingChangeEvent;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.MetadataIndexerProcessor;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.utils.Log;
+import org.jdom.Element;
+import org.jdom.output.XMLOutputter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.util.Set;
+
+import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+
+/**
+ * Process a metadata with an SQL search and replace.
+ * It is not as fast as a direct SQL UPDATE but will check
+ * that the document after the replace is still well-formed XML.
+ */
+@RequestMapping(value = {
+    "/{portal}/api/processes/db"
+})
+@Tag(name = "processes",
+    description = "Processing operations")
+@Controller("dbprocess")
+@ReadWriteController
+public class DatabaseProcessApi {
+
+    @Autowired
+    DataManager dataMan;
+
+    @Autowired
+    SchemaManager schemaMan;
+
+    @Autowired
+    SettingManager settingManager;
+
+    @io.swagger.v3.oas.annotations.Operation(
+        summary = "Preview of search and replace text.",
+        description =" When errors occur during processing, the processing report is returned in JSON format.")
+    @RequestMapping(
+        value = "/search-and-replace",
+        method = RequestMethod.GET,
+        consumes = {
+            MediaType.TEXT_HTML_VALUE,
+            MediaType.ALL_VALUE
+        },
+        produces = {
+            MediaType.ALL_VALUE
+        })
+    @ResponseBody
+    @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("hasAuthority('Editor')")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Processed records."),
+        @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_ONLY_EDITOR)
+    })
+    public Object previewProcessSearchAndReplace(
+        @Parameter(
+            description = "Use regular expression (may not be supported by all databases - tested with H2 and PostgreSQL)",
+            required = false
+        )
+        @RequestParam(
+            required = false,
+            defaultValue = "false"
+        )
+            boolean useRegexp,
+        @Parameter(
+            description = "Value to search for"
+        )
+        @RequestParam
+            String search,
+        @Parameter(
+            description = "Replacement"
+        )
+        @RequestParam(
+            defaultValue = ""
+        )
+            String replace,
+        @Parameter(
+            description = "regexpFlags"
+        )
+        @RequestParam(
+            required = false,
+            defaultValue = ""
+        )
+            String regexpFlags,
+        @Parameter(description = API_PARAM_RECORD_UUIDS_OR_SELECTION,
+            required = false,
+            example = "")
+        @RequestParam(required = false)
+            String[] uuids,
+        @Parameter(
+            description = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+            String bucket,
+        @Parameter(hidden = true)
+            HttpSession httpSession,
+        @Parameter(hidden = true)
+            HttpServletRequest request,
+        @Parameter(hidden = true)
+            HttpServletResponse response) throws IllegalArgumentException {
+        UserSession session = ApiUtils.getUserSession(httpSession);
+
+        MetadataReplacementProcessingReport processingReport =
+            new MetadataReplacementProcessingReport(search + "-" + replace);
+
+        Element preview = new Element("preview");
+
+        try {
+            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, bucket, session);
+
+            final String siteURL = request.getRequestURL().toString() + "?" + request.getQueryString();
+            for (String uuid : records) {
+                String id = dataMan.getMetadataId(uuid);
+                Log.info("org.fao.geonet.services.metadata",
+                    "Processing metadata for preview with id:" + id);
+
+                Element record = DatabaseProcessUtils.process(
+                    ApiUtils.createServiceContext(request),
+                    id, useRegexp, search, replace, regexpFlags,
+                    false, false,
+                    false, processingReport);
+                if (record != null) {
+                    preview.addContent(record.detach());
+                }
+            }
+        } catch (Exception exception) {
+            processingReport.addError(exception);
+        } finally {
+            processingReport.close();
+        }
+
+        // In case of errors during processing return report.
+        if (processingReport.getMetadataErrors().size() > 0) {
+            response.setHeader(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+            ObjectMapper mapper = new ObjectMapper();
+            try {
+                return mapper.writeValueAsString(processingReport);
+            } catch (JsonProcessingException errorReportException) {
+                return String.format("Failed to generate error report due to '%s'.",
+                    errorReportException.getMessage());
+            }
+        }
+
+        return preview;
+    }
+
+    @io.swagger.v3.oas.annotations.Operation(
+        summary = "Apply a database search and replace to one or more records",
+        description = ApiParams.API_OP_NOTE_PROCESS)
+    @RequestMapping(
+        value = "/search-and-replace",
+        method = RequestMethod.POST,
+        produces = {
+            MediaType.APPLICATION_JSON_VALUE
+        })
+    @ResponseBody
+    @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasAuthority('Editor')")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "Report about processed records."),
+        @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_ONLY_EDITOR)
+    })
+    public XsltMetadataProcessingReport processSearchAndReplace(
+        @Parameter(
+            description = "Use regular expression (may not be supported by all databases - tested with H2 and PostgreSQL)",
+            required = false
+        )
+        @RequestParam(
+            required = false,
+            defaultValue = "false"
+        )
+            boolean useRegexp,
+        @Parameter(
+            description = "Value to search for"
+        )
+        @RequestParam
+            String search,
+        @Parameter(
+            description = "Replacement"
+        )
+        @RequestParam(
+            defaultValue = ""
+        )
+            String replace,
+        @Parameter(
+            description = "regexpFlags"
+        )
+        @RequestParam(
+            required = false,
+            defaultValue = ""
+        )
+            String regexpFlags,
+        @Parameter(description = API_PARAM_RECORD_UUIDS_OR_SELECTION,
+            required = false,
+            example = "")
+        @RequestParam(required = false)
+            String[] uuids,
+        @Parameter(
+            description = ApiParams.API_PARAM_BUCKET_NAME,
+            required = false)
+        @RequestParam(
+            required = false
+        )
+            String bucket,
+        @Parameter(
+            description = ApiParams.API_PARAM_UPDATE_DATESTAMP,
+            required = false
+        )
+        @RequestParam(
+            required = false,
+            defaultValue = "true"
+        )
+            boolean updateDateStamp,
+        @Parameter(description = "Index after processing",
+            required = false,
+            example = "false")
+        @RequestParam(required = false, defaultValue = "true")
+            boolean index,
+        @Parameter(hidden = true)
+            HttpSession httpSession,
+        @Parameter(hidden = true)
+            HttpServletRequest request) throws Exception {
+        UserSession session = ApiUtils.getUserSession(httpSession);
+
+        MetadataReplacementProcessingReport processingReport =
+            new MetadataReplacementProcessingReport(search + "-" + replace);
+
+        try {
+            Set<String> records = ApiUtils.getUuidsParameterOrSelection(uuids, bucket, session);
+            UserSession userSession = ApiUtils.getUserSession(httpSession);
+
+            final String siteURL = request.getRequestURL().toString() + "?" + request.getQueryString();
+
+            processingReport.setTotalRecords(records.size());
+
+            BatchDatabaseUpdateMetadataReindexer m = new BatchDatabaseUpdateMetadataReindexer(
+                ApiUtils.createServiceContext(request),
+                dataMan, records, useRegexp, search, replace, regexpFlags, httpSession, siteURL,
+                processingReport, request, index, updateDateStamp, userSession.getUserIdAsInt());
+            m.process(settingManager.getSiteId());
+
+        } catch (Exception exception) {
+            processingReport.addError(exception);
+        } finally {
+            processingReport.close();
+        }
+
+        return processingReport;
+    }
+
+    static final class BatchDatabaseUpdateMetadataReindexer extends
+        MetadataIndexerProcessor {
+        private final boolean index;
+        private final boolean updateDateStamp;
+        Set<String> records;
+        boolean useRegexp;
+        String search;
+        String replace;
+        String regexpFlags;
+        String siteURL;
+        HttpSession session;
+        MetadataReplacementProcessingReport processingReport;
+        HttpServletRequest request;
+        ServiceContext context;
+        int userId;
+
+        public BatchDatabaseUpdateMetadataReindexer(ServiceContext context,
+                                                    DataManager dm,
+                                                    Set<String> records,
+                                                    boolean useRegexp,
+                                                    String search,
+                                                    String replace,
+                                                    String regexpFlags,
+                                                    HttpSession session,
+                                                    String siteURL,
+                                                    MetadataReplacementProcessingReport processingReport,
+                                                    HttpServletRequest request, boolean index,
+                                                    boolean updateDateStamp, int userId) {
+            super(dm);
+            this.records = records;
+            this.useRegexp = useRegexp;
+            this.search = search;
+            this.replace = replace;
+            this.regexpFlags = regexpFlags;
+            this.session = session;
+            this.index = index;
+            this.updateDateStamp = updateDateStamp;
+            this.siteURL = siteURL;
+            this.request = request;
+            this.processingReport = processingReport;
+            this.context = context;
+            this.userId = userId;
+        }
+
+        @Override
+        public void process(String catalogueId) throws Exception {
+            DataManager dataMan = context.getBean(DataManager.class);
+            ApplicationContext appContext = ApplicationContextHolder.get();
+            for (String uuid : this.records) {
+                String id = getDataManager().getMetadataId(uuid);
+                Log.info("org.fao.geonet.services.metadata",
+                    "Processing metadata with id:" + id);
+
+                Element beforeMetadata = dataMan.getMetadata(context, id, false, false, false);
+
+                Element record = DatabaseProcessUtils.process(
+                    ApiUtils.createServiceContext(request),
+                    id, useRegexp, search, replace, regexpFlags,
+                    true, index,
+                    updateDateStamp, processingReport);
+
+                Element afterMetadata = dataMan.getMetadata(context, id, false, false, false);
+
+                XMLOutputter outp = new XMLOutputter();
+                String xmlAfter = outp.outputString(afterMetadata);
+                String xmlBefore = outp.outputString(beforeMetadata);
+                new RecordProcessingChangeEvent(
+                    Long.parseLong(id), this.userId,
+                    xmlBefore, xmlAfter,
+                    processingReport.getProcessId()).publish(appContext);
+            }
+        }
+    }
+}

--- a/services/src/main/java/org/fao/geonet/api/processing/DatabaseProcessUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/DatabaseProcessUtils.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.api.processing;
+
+import jeeves.server.context.ServiceContext;
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.api.processing.report.MetadataReplacementProcessingReport;
+import org.fao.geonet.api.processing.report.XsltMetadataProcessingReport;
+import org.fao.geonet.domain.AbstractMetadata;
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.kernel.AccessManager;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.fao.geonet.kernel.datamanager.IMetadataSchemaUtils;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.lib.Lib;
+import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.repository.MetadataValidationRepository;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
+
+import java.util.Map;
+
+public class DatabaseProcessUtils {
+    /**
+     * Process a metadata with a database SQL query.
+     * Checks that the result of the query is still XML valid.
+     */
+    public static Element process(ServiceContext context, String id,
+                                  boolean useRegexp,
+                                  String search,
+                                  String replace,
+                                  String flags,
+                                  boolean save, boolean index,
+                                  boolean updateDateStamp,
+                                  MetadataReplacementProcessingReport report) throws Exception {
+        AccessManager accessMan = context.getBean(AccessManager.class);
+        DataManager dataMan = context.getBean(DataManager.class);
+        IMetadataUtils metadataUtils = context.getBean(IMetadataUtils.class);
+        MetadataRepository metadataRepository = context.getBean(MetadataRepository.class);
+
+        report.incrementProcessedRecords();
+
+        // When a record is deleted the UUID is in the selection manager
+        // and when retrieving id, return null
+        if (id == null) {
+            report.incrementNullRecords();
+            return null;
+        }
+
+        int iId = Integer.valueOf(id);
+        AbstractMetadata info = metadataUtils.findOne(id);
+
+
+        if (info == null) {
+            report.addNotFoundMetadataId(iId);
+        } else if (!accessMan.canEdit(context, id)) {
+            report.addNotEditableMetadataId(iId);
+        } else {
+            Element wellFormedXml = null;
+            try {
+                Lib.resource.checkEditPrivilege(context, id);
+
+                String updatedXml =
+                    useRegexp
+                        ? (StringUtils.isNotEmpty(flags)
+                          ? metadataRepository.selectOneWithRegexSearchAndReplaceWithFlags(
+                        info.getUuid(), search, replace, flags)
+                          : metadataRepository.selectOneWithRegexSearchAndReplace(
+                        info.getUuid(), search, replace))
+                        : metadataRepository.selectOneWithSearchAndReplace(
+                        info.getUuid(), search, replace);
+
+                // Check XML is still well formed.
+                wellFormedXml = Xml.loadString(updatedXml, false);
+
+                // --- save metadata and return status
+                if (save) {
+                    boolean validate = false;
+                    boolean ufo = true;
+                    String language = context.getLanguage();
+
+                    dataMan.updateMetadata(context, id, wellFormedXml, validate, ufo, index, language, new ISODate().toString(), updateDateStamp);
+                    if (index) {
+                        dataMan.indexMetadata(id, true);
+                    }
+                }
+
+                report.addMetadataId(iId);
+                // TODO : it could be relevant to list at least
+                // if there was any change in the record or not.
+                // Using hash on processMd and metadata ?
+            } catch (Exception e) {
+                report.addMetadataError(info, e);
+                context.error("  Processing failed with error " + e.getMessage());
+                context.error(e);
+            }
+            return wellFormedXml;
+        }
+        return null;
+    }
+}

--- a/services/src/main/java/org/fao/geonet/api/processing/XslProcessUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/XslProcessUtils.java
@@ -121,6 +121,8 @@ public class XslProcessUtils {
             Element processedMetadata = null;
             try {
                 boolean forEditing = false, withValidationErrors = false, keepXlinkAttributes = true;
+                Lib.resource.checkEditPrivilege(context, id);
+
                 Element md = metadataManager.getMetadata(context, id, forEditing, false, withValidationErrors, keepXlinkAttributes);
 
                 Map<String, Object> xslParameter = getDefaultXslParameters(context, settingsMan);
@@ -153,8 +155,6 @@ public class XslProcessUtils {
 
                 // --- save metadata and return status
                 if (save) {
-                    Lib.resource.checkEditPrivilege(context, id);
-
                     boolean validate = false;
                     boolean ufo = true;
                     String language = context.getLanguage();

--- a/services/src/test/java/org/fao/geonet/api/processing/DatabaseProcessUtilsTest.java
+++ b/services/src/test/java/org/fao/geonet/api/processing/DatabaseProcessUtilsTest.java
@@ -1,0 +1,111 @@
+package org.fao.geonet.api.processing;
+
+import jeeves.server.context.ServiceContext;
+import org.fao.geonet.api.processing.report.MetadataReplacementProcessingReport;
+import org.fao.geonet.api.processing.report.Report;
+import org.fao.geonet.domain.AbstractMetadata;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.mef.MEFLibIntegrationTest;
+import org.fao.geonet.services.AbstractServiceIntegrationTest;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class DatabaseProcessUtilsTest extends AbstractServiceIntegrationTest {
+
+    List<String> uuids = new ArrayList();
+    String metadataId = null;
+    ServiceContext context;
+
+    @Autowired
+    private IMetadataUtils repository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Before
+    public void loadSamples() throws Exception {
+        context = createServiceContext();
+        loginAsAdmin(context);
+
+        final MEFLibIntegrationTest.ImportMetadata importMetadata =
+            new MEFLibIntegrationTest.ImportMetadata(this, context);
+        importMetadata.getMefFilesToLoad().add("mef2-example-2md.zip");
+        importMetadata.invoke();
+        List<String> importedRecordUuids = importMetadata.getMetadataIds();
+
+        // Check record are imported
+        for (String id : importedRecordUuids) {
+            final String uuid = repository.findOne(Integer.valueOf(id)).getUuid();
+            uuids.add(uuid);
+            if (uuid.equals("0e1943d6-64e8-4430-827c-b465c3e9e55c")) {
+                metadataId = id;
+            }
+        }
+        assertEquals(3, repository.count());
+    }
+
+    @Test
+    public void testProcess() {
+        MetadataReplacementProcessingReport report = new MetadataReplacementProcessingReport("test");
+        String searchValue = "Localities in Victoria";
+        String replaceBy = "Localities in Hobart";
+        String searchPattern = "Localities in (.*)";
+        String replacePatternBy = "Points in $1";
+
+        boolean save = false, index = false, updateDateStamp = false;
+        try {
+            AbstractMetadata record = repository.findOne(metadataId);
+            assertEquals(true, record.getData().contains(searchValue));
+
+            Element updatedRecord = DatabaseProcessUtils.process(context, metadataId,
+                false, searchValue, replaceBy,
+                "", save, index, updateDateStamp, report);
+
+            assertEquals(1, report.getNumberOfRecordsProcessed());
+            assertEquals(false, Xml.getString(updatedRecord).contains(searchValue));
+            assertEquals(true, Xml.getString(updatedRecord).contains(replaceBy));
+
+            AbstractMetadata recordNotSavedInDb = repository.findOne(metadataId);
+            assertEquals(true, recordNotSavedInDb.getData().contains(searchValue));
+
+
+            save = true;
+            updatedRecord = DatabaseProcessUtils.process(context, metadataId,
+                false, searchValue, replaceBy,
+                "", save, index, updateDateStamp, report);
+            entityManager.flush();
+
+            AbstractMetadata recordSavedInDb = repository.findOne(metadataId);
+            assertEquals(false, recordSavedInDb.getData().contains(searchValue));
+            assertEquals(true, recordSavedInDb.getData().contains(replaceBy));
+
+
+            updatedRecord = DatabaseProcessUtils.process(context, metadataId,
+                true, searchPattern, replacePatternBy,
+                "", save, index, updateDateStamp, report);
+
+            assertEquals(true, Xml.getString(updatedRecord).contains("Points in Hobart"));
+
+            MetadataReplacementProcessingReport reportWithError = new MetadataReplacementProcessingReport("test");
+            DatabaseProcessUtils.process(context, metadataId,
+                false, "<gco:Character", "",
+                "", save, index, updateDateStamp, reportWithError);
+
+            assertEquals(1, reportWithError.getNumberOfRecordsWithErrors());
+            List<Report> reports = reportWithError.getMetadataErrors().get(metadataId);
+            assertEquals(true, reports.get(0).getMessage().contains("JDOMParseException"));
+        } catch (Exception e) {
+        }
+
+    }
+}


### PR DESCRIPTION
Quite often, users wants to update metadata records with a search and replace. The batch edit API does not handle all cases and we usually end up using SQL in database.

This adds an API endpoint to do search and replace (with or without regexp) relying on database capabilities. The operation still check the produced document is still valid XML and save it afterwards.


![image](https://user-images.githubusercontent.com/1701393/138308030-eb9add5e-a1cc-4666-be46-9651b132cb19.png)
