### PR TITLE
Aggregation / Add meta property to define a custom thesaurus id

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -601,7 +601,7 @@
       }
     };
 
-    function loadTranslation(fieldId) {
+    function loadTranslation(fieldId, thesaurus) {
       var keys = Object.keys(translationsToLoad[fieldId]);
       var deferred = $q.defer();
       if (keys.length > 0) {
@@ -609,7 +609,7 @@
         angular.copy(keys, uris);
         translationsToLoad[fieldId] = {};
         $http.post('../api/registries/vocabularies/keyword', gnUrlUtils.toKeyValue({
-          thesaurus: fieldId.replace(/th_(.*)_tree.key/, '$1'),
+          thesaurus: thesaurus || fieldId.replace(/th_(.*)_tree.key/, '$1'),
           id: encodeURIComponent(uris.join(',')),
           lang: gnLangs.getCurrent() + ',' + Object.keys(gnLangs.langs).join(',')
         }), {
@@ -626,7 +626,7 @@
       }
       return deferred.promise;
     };
-
+      
     function buildTree(list, fieldId, tree, meta) {
       var translateOnLoad = meta && meta.translateOnLoad;
       list.forEach(function(e) {
@@ -691,7 +691,7 @@
       buildTree(list, fieldId, tree, meta);
 
       if(Object.keys(translationsToLoad[fieldId]).length > 0) {
-        loadTranslation(fieldId, tree).then(function(translations) {
+        loadTranslation(fieldId, meta && meta.thesaurus).then(function(translations) {
           if (angular.isObject(translations)) {
             var t = {};
             t[gnLangs.current] = {};


### PR DESCRIPTION
It may be necessary when thesaurus filename contains "." which are converted to "-" (because Elasticsearch does not allow "." in field name).

```
      'th_dcsmm-area_tree.key':
        {
          'terms': {
            'field': 'th_dcsmm-area_tree.key',
            'size': 300
          },
          "meta": {
            "thesaurus": "dcsmm.area"
          }
        }
```