### PR TITLE
Admin / Thesaurus / Fix keyword init when browsing relation.

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
@@ -484,7 +484,7 @@
        * Edit an existing keyword, open the modal, search relations
        */
       $scope.editKeyword = function(k) {
-        $scope.keywordSelected = angular.isObject(k) ? angular.copy(k) : findKeywordByUri(k);
+        $scope.keywordSelected = angular.copy(angular.isObject(k) ? k : findKeywordByUri(k));
         $scope.keywordSelected.oldId = $scope.keywordSelected.uri;
 
         // create geo object (if not already there)

--- a/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
@@ -471,11 +471,20 @@
         });
       };
 
+      function findKeywordByUri(uri) {
+        for (var i = 0; i < $scope.keywords.length; i ++) {
+          if ($scope.keywords[i].uri === uri) {
+            return $scope.keywords[i]
+          }
+        }
+        return undefined;
+      }
+
       /**
        * Edit an existing keyword, open the modal, search relations
        */
       $scope.editKeyword = function(k) {
-        $scope.keywordSelected = angular.copy(k);
+        $scope.keywordSelected = angular.isObject(k) ? angular.copy(k) : findKeywordByUri(k);
         $scope.keywordSelected.oldId = $scope.keywordSelected.uri;
 
         // create geo object (if not already there)

--- a/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
@@ -474,7 +474,7 @@
       function findKeywordByUri(uri) {
         for (var i = 0; i < $scope.keywords.length; i ++) {
           if ($scope.keywords[i].uri === uri) {
-            return $scope.keywords[i]
+            return $scope.keywords[i];
           }
         }
         return undefined;

--- a/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
@@ -503,7 +503,7 @@
                 <h3 data-ng-translate="" data-ng-show="value.length !== 0">{{key | translate}}</h3>
                 <ul>
                   <li data-ng-repeat="k in value">
-                    <a data-ng-click="editKeyword(k)">{{k.value['#text']}}</a>
+                    <a data-ng-click="editKeyword(k.uri)">{{k.value['#text']}}</a>
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
Issue is due to the differences in the response of the keyword search API and the keyword relation API. Search keyword by URI to init it properly.