### PR TITLE
Indexing / Use final index field name in Java constant

### DIFF
--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -648,7 +648,7 @@ public final class Geonet {
         public static final String GROUP_WEBSITE = "_groupWebsite";
         public static final String LOGO = "_logo";
         public static final String OP_PREFIX = "op";
-        public static final String GROUP_PUBLISHED = "_groupPublished";
+        public static final String GROUP_PUBLISHED = "groupPublished";
         public static final String CAT = "_cat";
         public static final String STATUS = "mdStatus";
         public static final String STATUS_CHANGE_DATE = "mdStatusChangeDate";
@@ -657,7 +657,7 @@ public final class Geonet {
         public static final String VALID_INSPIRE = "_valid_inspire";
         public static final String ANY = "any";
         public static final String LOCALE = "locale";
-        public static final String IS_PUBLISHED_TO_ALL = "_isPublishedToAll";
+        public static final String IS_PUBLISHED_TO_ALL = "isPublishedToAll";
         public static final String FEEDBACKCOUNT = "feedbackCount";
         public static final String DRAFT = "draft";
         public static final String RESOURCETITLE = "resourceTitle";


### PR DESCRIPTION
When updating privileges for one record, buildFieldsForPrivileges was using the old field name with "_".
"_" was not allowed in Kibana field name. EsSearchManager was removing them in getPropertyName but not when using sharing API.