### PR TITLE
More like this / Use current title for the search

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
@@ -133,7 +133,7 @@
             if (scope.md == null) {
               return;
             }
-            query.query.bool.must[0].more_like_this.like = scope.md.resourceTitleObject.default;
+            query.query.bool.must[0].more_like_this.like = scope.md.resourceTitle;
             $http.post('../api/search/records/_search', query).then(function (r) {
               scope.similarDocuments = r.data.hits;
             })


### PR DESCRIPTION
Some schema does not have Object.default eg. iso19110 because not multilingual.

Use current language for the similarity search