### PR TITLE
Formatter / Table rendering / Fix error when no child in element

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -601,16 +601,21 @@
 
     <xsl:variable name="root"
                   select="."/>
-    <xsl:for-each select="$tableConfig/row/col[@xpath]">
-      <xsl:variable name="node">
-        <saxon:call-template name="{concat('evaluate-', $schema)}">
-          <xsl:with-param name="base" select="$root/*"/>
-          <xsl:with-param name="in" select="concat('/', @xpath)"/>
-        </saxon:call-template>
-      </xsl:variable>
-      <td><xsl:apply-templates mode="render-value"
-                               select="if ($node//@codeListValue) then $node//@codeListValue else $node"/></td>
-    </xsl:for-each>
+
+    <!-- Only if child context. eg. <gmd:pointOfContact xlink:href=
+    may not have children if xlink fails to resolve. -->
+    <xsl:if test="$root/*">
+      <xsl:for-each select="$tableConfig/row/col[@xpath]">
+        <xsl:variable name="node">
+          <saxon:call-template name="{concat('evaluate-', $schema)}">
+            <xsl:with-param name="base" select="$root/*"/>
+            <xsl:with-param name="in" select="concat('/', @xpath)"/>
+          </saxon:call-template>
+        </xsl:variable>
+        <td><xsl:apply-templates mode="render-value"
+                                 select="if ($node//@codeListValue) then $node//@codeListValue else $node"/></td>
+      </xsl:for-each>
+    </xsl:if>
   </xsl:template>
 
 


### PR DESCRIPTION
Exception was

```
java.lang.RuntimeException: net.sf.saxon.trans.XPathException: An empty sequence is not allowed as the value of parameter $base
```