### PR TITLE
DOI / Add public URL settings.

### DIFF
--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiClient.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiClient.java
@@ -36,7 +36,6 @@ import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.utils.GeonetHttpRequestFactory;
 import org.fao.geonet.utils.Log;
 import org.apache.commons.httpclient.HttpStatus;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.client.ClientHttpResponse;
 
 import java.io.InputStreamReader;
@@ -57,7 +56,8 @@ public class DoiClient {
     public static final String ALL_DOI_ENTITY = "All DOI";
     public static final String DOI_METADATA_ENTITY = "DOI metadata";
 
-    private String serverUrl;
+    private String apiUrl;
+    private String doiPublicUrl;
     private String username;
     private String password;
 
@@ -65,12 +65,13 @@ public class DoiClient {
 
     protected GeonetHttpRequestFactory requestFactory;
 
-    public DoiClient(String serverUrl, String username, String password) {
-        this(serverUrl, username, password, true);
+    public DoiClient(String apiUrl, String username, String password, String doiPublicUrl) {
+        this(apiUrl, username, password, doiPublicUrl, true);
     }
 
-    public DoiClient(String serverUrl, String username, String password, boolean testMode) {
-        this.serverUrl = serverUrl.endsWith("/") ? serverUrl : serverUrl + "/";
+    public DoiClient(String apiUrl, String username, String password, String doiPublicUrl, boolean testMode) {
+        this.apiUrl = apiUrl.endsWith("/") ? apiUrl : apiUrl + "/";
+        this.doiPublicUrl = doiPublicUrl.endsWith("/") ? doiPublicUrl : doiPublicUrl + "/";
         this.username = username;
         this.password = password;
         this.testMode = testMode;
@@ -177,7 +178,7 @@ public class DoiClient {
         HttpDelete deleteMethod = null;
 
         try {
-            Log.debug(LOGGER_NAME, "   -- URL: " + this.serverUrl + "/metadata");
+            Log.debug(LOGGER_NAME, "   -- URL: " + this.apiUrl + "/metadata");
 
             deleteMethod = new HttpDelete(createUrl("metadata/" + doi));
 
@@ -217,7 +218,7 @@ public class DoiClient {
         HttpDelete deleteMethod = null;
 
         try {
-            Log.debug(LOGGER_NAME, "   -- URL: " + this.serverUrl + "/metadata");
+            Log.debug(LOGGER_NAME, "   -- URL: " + this.apiUrl + "/metadata");
 
             deleteMethod = new HttpDelete(createUrl("doi/" + doi));
 
@@ -351,14 +352,21 @@ public class DoiClient {
     }
 
     /**
-     * Builds service url with server url.
+     * Builds API endpoint url based on server URL configured in settings.
      *
-     * @param service
-     * @return
+     * eg. https://mds.datacite.org/doi/10.12770/38e00808-ffca-4266-943f-b691d3ca0bec
      */
     public String createUrl(String service) {
-        return this.serverUrl +
-            (this.serverUrl.endsWith("/") ? "" : "/") +
-            service;
+        return this.apiUrl + service;
+    }
+
+    /**
+     * Builds final DOI url based on public URL configured in settings.
+     * Default is https://doi.org.
+     *
+     * eg. https://doi.org/10.17882/80771
+     */
+    public String createPublicUrl(String doi) {
+        return this.doiPublicUrl + doi;
     }
 }

--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiManager.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiManager.java
@@ -67,6 +67,7 @@ public class DoiManager {
     private static final String DOI_REMOVE_XSL_PROCESS = "process/doi-remove.xsl";
     public static final String DATACITE_XSL_CONVERSION_FILE = "formatter/datacite/view.xsl";
     public static final String DOI_PREFIX_PARAMETER = "doiPrefix";
+    public static final String DOI_DEFAULT_URL = "https://doi.org/";
 
     private DoiClient client;
     private String doiPrefix;
@@ -106,6 +107,10 @@ public class DoiManager {
         if (sm != null) {
 
             String serverUrl = sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_DOIURL);
+            String doiPublicUrl = sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_DOIPUBLICURL);
+            if (StringUtils.isEmpty(doiPublicUrl)) {
+                doiPublicUrl = DOI_DEFAULT_URL;
+            }
             String username = sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_DOIUSERNAME);
             String password = sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_DOIPASSWORD);
 
@@ -140,7 +145,7 @@ public class DoiManager {
                 Log.debug(DoiSettings.LOGGER_NAME,
                     "DOI configuration looks perfect.");
                 // TODO: Check connection ?
-                this.client = new DoiClient(serverUrl, username, password);
+                this.client = new DoiClient(serverUrl, username, password, doiPublicUrl);
                 initialised = true;
             }
         }
@@ -229,14 +234,15 @@ public class DoiManager {
             String currentDoi = schema.queryString(DOI_GET_SAVED_QUERY, xml);
             if (StringUtils.isNotEmpty(currentDoi)) {
                 // Current doi does not match the one going to be inserted. This is odd
-                if (!currentDoi.equals(client.createUrl("doi") + "/" + doi)) {
+                String newDoi = client.createPublicUrl(doi);
+                if (!currentDoi.equals(newDoi)) {
                     throw new DoiClientException(String.format(
                         "Record '%s' already contains a DOI <a href='%s'>%s</a> which is not equal " +
                             "to the DOI about to be created (ie. '%s'). " +
                             "Maybe current DOI does not correspond to that record? " +
                             "This may happen when creating a copy of a record having " +
                             "an existing DOI.",
-                        metadata.getUuid(), currentDoi, currentDoi, client.createUrl("") + doi));
+                        metadata.getUuid(), currentDoi, currentDoi, newDoi));
                 }
 
                 throw new ResourceAlreadyExistException(String.format(
@@ -372,7 +378,7 @@ public class DoiManager {
                         "{{uuid}}", metadata.getUuid());
         doiInfo.put("doiLandingPage", landingPage);
         doiInfo.put("doiUrl",
-            client.createUrl("doi") + "/" + doiInfo.get("doi"));
+            client.createPublicUrl(doiInfo.get("doi")));
         client.createDoi(doiInfo.get("doi"), landingPage);
 
 

--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiSettings.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiSettings.java
@@ -28,6 +28,8 @@ package org.fao.geonet.doi.client;
 public class DoiSettings {
     public static final String SETTING_PUBLICATION_DOI_DOIURL =
         "system/publication/doi/doiurl";
+    public static final String SETTING_PUBLICATION_DOI_DOIPUBLICURL =
+        "system/publication/doi/doipublicurl";
     public static final String SETTING_PUBLICATION_DOI_DOIUSERNAME =
         "system/publication/doi/doiusername";
     public static final String SETTING_PUBLICATION_DOI_DOIPASSWORD =

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -767,6 +767,8 @@
     "system/publication": "Publication",
     "system/publication/doi/doienabled": "Allow creation of Digital Object Identifier (DOI)",
     "system/publication/doi/doienabled-help": "A Digital Object Identifier (DOI) is an alphanumeric string assigned to uniquely identify an object. It is tied to a metadata description of the object as well as to a digital location, such as a URL, where all the details about the object are accessible. More information available on <a href='https://www.datacite.org/dois.html'>DataCite website</a>.",
+    "system/publication/doi/doipublicurl": "The final DOI URL prefix",
+    "system/publication/doi/doipublicurl-help": "Keep it empty to use the default https://doi.org prefix. Use https://mds.test.datacite.org/doi when using the test API.",
     "system/publication/doi/doiurl": "The DataCite API endpoint",
     "system/publication/doi/doiurl-help": "Usually https://mds.datacite.org or https://mds.test.datacite.org for testing.",
     "system/publication/doi/doiusername": "Your DataCite username",

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -700,6 +700,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/publication/doi/doipassword', '', 0, 100194, 'y', 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doikey', '', 0, 110095, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doilandingpagetemplate', 'http://localhost:8080/geonetwork/srv/resources/records/{{uuid}}', 0, 100195, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doipublicurl', '', 0, 100196, 'n');
 
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/security/passwordEnforcement/minLength', '6', 1, 12000, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/security/passwordEnforcement/maxLength', '20', 1, 12001, 'n');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v406/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v406/migrate-default.sql
@@ -1,5 +1,6 @@
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/remotevalidation/nodeid', '', 0, 7212, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/remotevalidation/apikey', '', 0, 7213, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doipublicurl', '', 0, 100196, 'n');
 
 DELETE FROM Settings WHERE name = 'system/server/securePort';
 


### PR DESCRIPTION
Before the API url was used instead of the default https://doi.org prefix.

![image](https://user-images.githubusercontent.com/1701393/143917534-680a590c-694a-4102-9418-b226f2939eba.png)

Keep the setting empty to use the default. When using the test API, user can set a custom value.