### PR TITLE
XSL / Add utility to get text from HTML

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -34,6 +34,7 @@ import com.neovisionaries.i18n.LanguageCode;
 import org.fao.geonet.api.records.attachments.FilesystemStoreResourceContainer;
 import org.fao.geonet.api.records.attachments.Store;
 import org.fao.geonet.domain.MetadataResourceContainer;
+import org.jsoup.Jsoup;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.MultiPolygon;
 import jeeves.component.ProfileManager;
@@ -643,6 +644,10 @@ public final class XslUtil {
             Log.error(Geonet.GEONETWORK, "XMLtoJSON conversion I/O error. Error is " + e.getMessage() + ". XML is " + xml.toString());
         }
         return "";
+    }
+
+    public static String html2text(String html) {
+        return Jsoup.parse(html).text();
     }
 
     /**


### PR DESCRIPTION
This is useful when input records contains HTML which can't be parsed as XML.

Use this in import process.