### PR TITLE
Editor / Collapse directive

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -872,7 +872,9 @@
             var content = legend.nextAll();
             //open up the content needed - toggle the slide-
             //if visible, slide up, if not slidedown.
-            content.slideToggle(attrs.duration || 250, function() {
+            content.filter(function(i, e) {
+              return $(e).css('visibility') !== 'hidden';
+            }).slideToggle(attrs.duration || 250, function() {
               //execute this after slideToggle is done
               //change the icon of the legend based on
               // visibility of content div


### PR DESCRIPTION
It was switching visibility of contained elements (visible one > hidden, hidden > visible) when we are forcing some element to not be visible 

eg. with something like
```css
.gn-tab-eo-access-and-usage {
  .gn-processStep .gn-level,
  .gn-resourceSpecificUsage .gn-specificUsage,
  .gn-resourceSpecificUsage .gn-userDeterminedLimitations,
  .gn-identifiedIssues .gn-add-field,
  .gn-required > label:after {
    display: none;
    visibility: hidden;
  }
```

Add `visibility` attribute to make distinction between elements to keep hidden and elements to switch.


![image](https://user-images.githubusercontent.com/1701393/145182884-f3ee2a90-a728-485f-a620-1ae4d951b461.png)

collasped is

![image](https://user-images.githubusercontent.com/1701393/145182918-7d690358-38f7-480c-a2eb-fe0258139459.png)
