### PR TITLE
Editor / Online source / Config / Add choices for URL

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -128,7 +128,7 @@
 
                 <div id="gn-addonlinesrc-url-list-single-row"
                      class="col-sm-9" data-ng-if="!isFieldMultilingual('url')">
-                  <div data-ng-class="{'input-group': OGCProtocol != null}">
+                  <div data-ng-class="{'input-group': (OGCProtocol != null || params.linkType.fields.url.choices)}">
                     <input data-ng-model="params.url"
                            data-ng-model-options="{debounce: 500}"
                            data-ng-required="params.linkType.fields.url.required"
@@ -139,16 +139,33 @@
                            id="gn-addonlinesrc-url-list-single-input"
                            data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.url.tooltip}}"
                            placeholder="{{params.linkType.fields.url.placeholder || 'https://...'}}">
-                    <span class="input-group-btn" data-ng-show="OGCProtocol != null">
-                    <!-- Refresh Grid Button -->
-                    <button id="gn-addonlinesrc-url-list-single-button"
-                            type="button"
-                            class="btn btn-warning"
-                            title="{{'loadCapabilitiesLayers' | translate}}"
-                            data-gn-click-and-spin="loadCurrentLink(true)">
-                      <i class="fa fa-refresh"/>
-                    </button>
-                  </span>
+                    <span class="input-group-btn"
+                          data-ng-show="OGCProtocol != null">
+                      <!-- Refresh Grid Button -->
+                      <button id="gn-addonlinesrc-url-list-single-button"
+                              type="button"
+                              class="btn btn-warning"
+                              title="{{'loadCapabilitiesLayers' | translate}}"
+                              data-gn-click-and-spin="loadCurrentLink(true)">
+                        <i class="fa fa-refresh"/>
+                      </button>
+                    </span>
+                    <span class="input-group-btn"
+                          data-ng-show="params.linkType.fields.url.choices">
+                      <button type="button"
+                              class="btn btn-default dropdown-toggle"
+                              data-ng-if="params.linkType.fields.url.choices"
+                              data-toggle="dropdown"
+                              aria-haspopup="true" aria-expanded="false">
+                        <span class="caret"></span>
+                      </button>
+                      <ul class="dropdown-menu"
+                          data-ng-if="params.linkType.fields.url.choices">
+                        <li data-ng-repeat="c in params.linkType.fields.url.choices">
+                          <a data-ng-click="params.url = c;">{{c}}</a>
+                        </li>
+                      </ul>
+                    </span>
                   </div>
                 </div>
 


### PR DESCRIPTION
In some case, the URL to use is always the same. Provide options to set a list of URLs for a type of link

eg. 

```json
      },{
        "group": "services",
        "label": "OpenSearch",
        "copyLabel": "desc",
        "icon": "fa gn-icon-onlinesrc",
        "process": "onlinesrc-add",
        "fields": {
          "url": {
            "isMultilingual": false,
            "choices": ["https://opensearch.ifremer.fr/", "https://cmr.earthdata.nasa.gov/opensearch/"]
```


![image](https://user-images.githubusercontent.com/1701393/145194778-e86eb10a-0fb1-472f-9245-4bcb08cbfff2.png)
