### PR TITLE
Record view / Back to search / Fix tag filter on advanced view.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -153,7 +153,7 @@
                   <span class="badge"><xsl:copy-of select="."/></span>
                 </xsl:when>
                 <xsl:otherwise>
-                  <a href='#/search?query_string=%7B"tag":%7B"{.}":true%7D%7D'>
+                  <a href='#/search?query_string=%7B"tag.\\*":%7B"{.}":true%7D%7D'>
                     <span class="badge"><xsl:copy-of select="."/></span>
                   </a>
                 </xsl:otherwise>
@@ -173,7 +173,7 @@
                 <span class="badge"><xsl:copy-of select="."/></span>
               </xsl:when>
               <xsl:otherwise>
-                <a href='#/search?query_string=%7B"tag":%7B"{.}":true%7D%7D'>
+                <a href='#/search?query_string=%7B"tag.\\*":%7B"{.}":true%7D%7D'>
                   <span class="badge"><xsl:copy-of select="."/></span>
                 </a>
               </xsl:otherwise>

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
@@ -221,18 +221,17 @@
         // query string is set.
         var isFilterFromRecordView =
           state.old.path.indexOf(that.METADATA) === 0
-          && state.current.params.query_string;
+          && !!state.current.params.query_string;
 
         if (state.old.path != '' &&
             state.old.path != that.SEARCH &&
             state.old.path != that.HOME &&
-            !isFilterFromRecordView &&
             state.current.path == that.SEARCH) {
           if (that.isMdView(state.old.path)) {
             $rootScope.$broadcast('locationBackToSearchFromMdview');
           }
           $rootScope.$broadcast('locationBackToSearch');
-          that.restoreSearch();
+          !isFilterFromRecordView && that.restoreSearch();
         }
         if (that.isSearch(state.old.path) &&
             !that.isSearch(state.current.path)) {


### PR DESCRIPTION
Default record view was ok because doing location change in JS.
Here we restore last search when coming from /metadata only if no query_string set in new state.