### PR TITLE
Harvester / CSW / Do not report last harvesting changes if early failure

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
@@ -109,7 +109,7 @@ class Harvester implements IHarvester<HarvestResult> {
         //--- perform all searches
 
         boolean error = false;
-        HarvestResult result = null;
+        HarvestResult result = new HarvestResult();
     	Set<String> uuids = new HashSet<String>();
         try {
             Aligner aligner = new Aligner(cancelMonitor, context, server, params, log);


### PR DESCRIPTION
Eg. when the GetRecords query fails, then no HarvestResult is created and the last harvesting task report was cloned due to https://github.com/geonetwork/core-geonetwork/commit/df50402bc4decf1d3bea49ca023fdd69b3a4e988.

Return an empty result report, the harvester did nothing.