### PR TITLE
CSW / Portal capabilities should not use the default

### DIFF
--- a/csw-server/src/main/java/org/fao/geonet/component/csw/GetCapabilities.java
+++ b/csw-server/src/main/java/org/fao/geonet/component/csw/GetCapabilities.java
@@ -110,11 +110,14 @@ public class GetCapabilities extends AbstractOperation implements CatalogService
             final Source source = sourceRepository.findById(nodeinfo.getId()).get();
             if(source.getServiceRecord() != null) {
                 recordUuidToUseForCapability = source.getServiceRecord().toString();
+            } else {
+                recordUuidToUseForCapability = "-1";
             }
         }
         Element capabilities = null;
         String message = null;
-        if (StringUtils.isNotEmpty(recordUuidToUseForCapability) && !"-1".equals(recordUuidToUseForCapability)) {
+        if (StringUtils.isNotEmpty(recordUuidToUseForCapability)
+            && !"-1".equals(recordUuidToUseForCapability)) {
             Metadata record = metadataRepository.findOneByUuid(recordUuidToUseForCapability);
             if (record != null) {
                 try {


### PR DESCRIPTION
If the portal as a specific discovery service record use it.
If not, use the default capabilities doc and not the service metadata record declared for the main node.

When the main portal also has a service record to use, the URL of all operations were not pointing to the portal URL. The portal name was also not used.

If user want a custom capabilities, it has to create a dedicated service metadata for the portal.

Related to https://github.com/geonetwork/core-geonetwork/pull/4390