### PR TITLE
Build / Fix JS error.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/harvester/HarvesterDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/harvester/HarvesterDirective.js
@@ -348,7 +348,7 @@
               },
               {
                 source: substringMatcher(scope.cswCriteriaTranslated),
-                limit: Infinity,
+                limit: Infinity
               });
 
               field.bind('typeahead:selected', function() {


### PR DESCRIPTION
```
SEVERE: /catalog/components/admin/harvester/HarvesterDirective.js:351: ERROR - Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.
                limit: Infinity,
```
Related https://github.com/titellus/core-geonetwork/pull/96