### PR TITLE
User feedback / Add email notification and admin console

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -28,19 +28,7 @@ import jeeves.server.context.ServiceContext;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.AbstractMetadata;
-import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataDraft;
-import org.fao.geonet.domain.MetadataStatus;
-import org.fao.geonet.domain.Pair;
-import org.fao.geonet.domain.Profile;
-import org.fao.geonet.domain.ReservedOperation;
-import org.fao.geonet.domain.StatusValue;
-import org.fao.geonet.domain.StatusValueNotificationLevel;
-import org.fao.geonet.domain.StatusValueType;
-import org.fao.geonet.domain.User;
-import org.fao.geonet.domain.User_;
+import org.fao.geonet.domain.*;
 import org.fao.geonet.events.md.MetadataStatusChanged;
 import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.DataManager;
@@ -49,11 +37,7 @@ import org.fao.geonet.kernel.datamanager.IMetadataStatus;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
-import org.fao.geonet.repository.MetadataDraftRepository;
-import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.SortUtils;
-import org.fao.geonet.repository.StatusValueRepository;
-import org.fao.geonet.repository.UserRepository;
+import org.fao.geonet.repository.*;
 import org.fao.geonet.util.MailUtil;
 import org.fao.geonet.util.XslUtil;
 import org.fao.geonet.utils.Log;
@@ -84,7 +68,7 @@ public class DefaultStatusActions implements StatusActions {
     protected boolean emailNotes = true;
     private String from, replyTo, replyToDescr;
     private StatusValueRepository _statusValueRepository;
-    private IMetadataStatus metadataStatusManager;
+    protected IMetadataStatus metadataStatusManager;
 
     /**
      * Constructor.
@@ -247,7 +231,7 @@ public class DefaultStatusActions implements StatusActions {
      * @param status
      * @throws Exception
      */
-    private void notify(List<User> userToNotify, MetadataStatus status) throws Exception {
+    protected void notify(List<User> userToNotify, MetadataStatus status) throws Exception {
         ResourceBundle messages = ResourceBundle.getBundle("org.fao.geonet.api.Messages", new Locale(this.language));
 
         String translatedStatusName = getTranslatedStatusName(status.getStatusValue().getId());
@@ -309,33 +293,34 @@ public class DefaultStatusActions implements StatusActions {
      */
     protected List<User> getUserToNotify(MetadataStatus status) {
         StatusValueNotificationLevel notificationLevel = status.getStatusValue().getNotificationLevel();
-        UserRepository userRepository = context.getBean(UserRepository.class);
-        List<User> users = new ArrayList<>();
-
         // TODO: Status does not provide batch update
         // So taking care of one record at a time.
         // Currently the code could notify a mix of reviewers
         // if records are not in the same groups. To be improved.
         Set<Integer> listOfId = new HashSet<>(1);
         listOfId.add(status.getMetadataId());
+        return getUserToNotify(notificationLevel, listOfId, status.getOwner());
+    }
+
+    static public List<User> getUserToNotify(StatusValueNotificationLevel notificationLevel, Set<Integer> recordIds, Integer ownerId) {
+        UserRepository userRepository = ApplicationContextHolder.get().getBean(UserRepository.class);
+        List<User> users = new ArrayList<>();
 
         if (notificationLevel != null) {
             if (notificationLevel == StatusValueNotificationLevel.statusUserOwner) {
-                Optional<User> owner = userRepository.findById(status.getOwner());
+                Optional<User> owner = userRepository.findById(ownerId);
 
                 if (owner.isPresent()) {
                     users.add(owner.get());
                 }
             } else if (notificationLevel == StatusValueNotificationLevel.recordProfileReviewer) {
-                List<Pair<Integer, User>> results = userRepository.findAllByGroupOwnerNameAndProfile(listOfId,
-                    Profile.Reviewer);
+                List<Pair<Integer, User>> results = userRepository.findAllByGroupOwnerNameAndProfile(recordIds, Profile.Reviewer);
                 Collections.sort(results, Comparator.comparing(s -> s.two().getName()));
-
                 for (Pair<Integer, User> p : results) {
                     users.add(p.two());
                 }
             } else if (notificationLevel == StatusValueNotificationLevel.recordUserAuthor) {
-                Iterable<Metadata> records = this.context.getBean(MetadataRepository.class).findAllById(listOfId);
+                Iterable<Metadata> records = ApplicationContextHolder.get().getBean(MetadataRepository.class).findAllById(recordIds);
                 for (Metadata r : records) {
                     Optional<User> owner = userRepository.findById(r.getSourceInfo().getOwner());
 
@@ -345,7 +330,7 @@ public class DefaultStatusActions implements StatusActions {
                 }
 
                 // Check metadata drafts
-                Iterable<MetadataDraft> recordsDraft = this.context.getBean(MetadataDraftRepository.class).findAllById(listOfId);
+                Iterable<MetadataDraft> recordsDraft = ApplicationContextHolder.get().getBean(MetadataDraftRepository.class).findAllById(recordIds);
 
                 for (MetadataDraft r : recordsDraft) {
                     Optional<User> owner = userRepository.findById(r.getSourceInfo().getOwner());
@@ -378,7 +363,7 @@ public class DefaultStatusActions implements StatusActions {
      *
      * @param mdId The metadata id to unset privileges on
      */
-    private void unsetAllOperations(int mdId) throws Exception {
+    protected void unsetAllOperations(int mdId) throws Exception {
         Log.trace(Geonet.DATA_MANAGER, "DefaultStatusActions.unsetAllOperations(" + mdId + ")");
 
         int allGroup = 1;

--- a/core/src/main/java/org/fao/geonet/kernel/setting/Settings.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/Settings.java
@@ -83,6 +83,7 @@ public class Settings {
     public static final String SYSTEM_USERFEEDBACK_ENABLE = "system/userFeedback/enable";
     public static final String SYSTEM_USER_LASTNOTIFICATIONDATE = "system/userFeedback/lastNotificationDate";
     public static final String SYSTEM_LOCALRATING_ENABLE = "system/localrating/enable";
+    public static final String SYSTEM_LOCALRATING_NOTIFICATIONLEVEL = "system/localrating/notificationLevel";
     public static final String SYSTEM_XLINK_RESOLVER_IGNORE = "system/xlinkResolver/ignore";
     public static final String SYSTEM_HIDEWITHHELDELEMENTS_ENABLE_LOGGING = "system/hidewithheldelements/enableLogging";
     public static final String SYSTEM_AUTOFIXING_ENABLE = "system/autofixing/enable";

--- a/core/src/main/resources/org/fao/geonet/api/Messages.properties
+++ b/core/src/main/resources/org/fao/geonet/api/Messages.properties
@@ -77,6 +77,8 @@ register_email_message=Dear User,\n\
   \n\
   Yours sincerely,\n\
   The %s team.
+new_user_rating=%s / New user rating on %s
+new_user_rating_text=See record %sapi/records/%s
 user_feedback_title=%s / User feedback on %s / %s
 user_feedback_text=User %s (%s - %s)\n\
   - Email: %s\n\

--- a/core/src/main/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/main/resources/org/fao/geonet/api/Messages_fre.properties
@@ -65,18 +65,20 @@ register_email_message=Cher utilisateur,\n\
   \n\
   Salutations,\n\
   L'\u00E9quipe %s.
-user_feedback_title=%s / User feedback on %s / %s
-user_feedback_text=User %s (%s - %s)\n\
+new_user_rating=%s / Nouvelle évaluation faite pour %s
+new_user_rating_text=Consulter la fiche %sapi/records/%s
+user_feedback_title=%s / Nouveau commentaire sur %s / %s
+user_feedback_text=Utilisateur %s (%s - %s)\n\
   - Email: %s\n\
-  - Phone: %s \n\
-  sent a feedback on %s record.\n\
+  - T\u00E9l\u00E9phone: %s \n\
+  a envoy\u00E9 un commentaire sur la fiche %s.\n\
   \n\
-  Feedback type: %s \n\
-  Feedback category: %s \n\
+  Type : %s \n\
+  Cat\u00E9gorie : %s \n\
   \n\
   %s \n\
   \n\
-  See record %s/api/records/%s
+  Consulter la fiche %s/api/records/%s
 status_email_text=L'utilisateur %s (%s) a \u00E9dit\u00E9 une fiche #%s
 # SiteName / Workflow / recordTitle statusName by userName
 status_change_default_email_subject={0} / Cycle de vie / '{{'index:resourceTitleObject'}}' {1} par {2}

--- a/core/src/main/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/main/resources/org/fao/geonet/api/Messages_fre.properties
@@ -105,14 +105,14 @@ Consulter la fiche : \n\
 # TODO: Link to DOI creation panel
 
 api.groups.group_not_found=Le groupe avec l'identifiant ''{0}'' n'a pas \u00E9t\u00E9 trouv\u00E9 dans le catalogue.
-user_watchlist_subject=%s / %d mises Ã  jour dans vos fiches surveill\u00E9es %s
+user_watchlist_subject=%s / %d mises \u00e0 jour dans vos fiches surveill\u00E9es %s
 user_watchlist_message_record=<li><a href="{{link}}">{{index:resourceTitleObject}}</a></li>
-user_watchlist_message=Les fiches suivantes ont \u00E9t\u00E9 mises Ã  jour :\n\
+user_watchlist_message=Les fiches suivantes ont \u00E9t\u00E9 mises \u00e0 jour :\n\
       <ul>%s</ul>\n\
       \n\
-      DerniÃ¨re notification : %s.\n\
+      Derni\u00e8re notification : %s.\n\
       <div itemscope itemtype="http://schema.org/EmailMessage">\n\
-        <meta itemprop="description" content="Voir les mises Ã  jour"/>\n\
+        <meta itemprop="description" content="Voir les mises \u00e0 jour"/>\n\
         <div itemprop="potentialAction" itemscope itemtype="http://schema.org/ViewAction">\n\
         <link itemprop="url" content="%s"/>\n\
         <meta itemprop="name" content="Voir les mises Ã  jour"/>\n\

--- a/core/src/main/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/main/resources/org/fao/geonet/api/Messages_fre.properties
@@ -65,7 +65,7 @@ register_email_message=Cher utilisateur,\n\
   \n\
   Salutations,\n\
   L'\u00E9quipe %s.
-new_user_rating=%s / Nouvelle �valuation faite pour %s
+new_user_rating=%s / Nouvelle \u00E9valuation faite pour %s
 new_user_rating_text=Consulter la fiche %sapi/records/%s
 user_feedback_title=%s / Nouveau commentaire sur %s / %s
 user_feedback_text=Utilisateur %s (%s - %s)\n\
@@ -105,17 +105,17 @@ Consulter la fiche : \n\
 # TODO: Link to DOI creation panel
 
 api.groups.group_not_found=Le groupe avec l'identifiant ''{0}'' n'a pas \u00E9t\u00E9 trouv\u00E9 dans le catalogue.
-user_watchlist_subject=%s / %d mises à jour dans vos fiches surveill\u00E9es %s
+user_watchlist_subject=%s / %d mises Ã  jour dans vos fiches surveill\u00E9es %s
 user_watchlist_message_record=<li><a href="{{link}}">{{index:resourceTitleObject}}</a></li>
-user_watchlist_message=Les fiches suivantes ont \u00E9t\u00E9 mises à jour :\n\
+user_watchlist_message=Les fiches suivantes ont \u00E9t\u00E9 mises Ã  jour :\n\
       <ul>%s</ul>\n\
       \n\
-      Dernière notification : %s.\n\
+      DerniÃ¨re notification : %s.\n\
       <div itemscope itemtype="http://schema.org/EmailMessage">\n\
-        <meta itemprop="description" content="Voir les mises à jour"/>\n\
+        <meta itemprop="description" content="Voir les mises Ã  jour"/>\n\
         <div itemprop="potentialAction" itemscope itemtype="http://schema.org/ViewAction">\n\
         <link itemprop="url" content="%s"/>\n\
-        <meta itemprop="name" content="Voir les mises à jour"/>\n\
+        <meta itemprop="name" content="Voir les mises Ã  jour"/>\n\
         </div>\n\
       </div>
 self_registration_disabled=User self-registration is disabled

--- a/core/src/main/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/main/resources/org/fao/geonet/api/Messages_fre.properties
@@ -115,7 +115,7 @@ user_watchlist_message=Les fiches suivantes ont \u00E9t\u00E9 mises \u00e0 jour 
         <meta itemprop="description" content="Voir les mises \u00e0 jour"/>\n\
         <div itemprop="potentialAction" itemscope itemtype="http://schema.org/ViewAction">\n\
         <link itemprop="url" content="%s"/>\n\
-        <meta itemprop="name" content="Voir les mises Ã  jour"/>\n\
+        <meta itemprop="name" content="Voir les mises \u00e0 jour"/>\n\
         </div>\n\
       </div>
 self_registration_disabled=User self-registration is disabled

--- a/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
@@ -48,13 +48,7 @@ import org.fao.geonet.api.site.model.SettingsListResponse;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.doi.client.DoiManager;
-import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.MetadataSourceInfo_;
-import org.fao.geonet.domain.Metadata_;
-import org.fao.geonet.domain.Profile;
-import org.fao.geonet.domain.Setting;
-import org.fao.geonet.domain.SettingDataType;
-import org.fao.geonet.domain.Source;
+import org.fao.geonet.domain.*;
 import org.fao.geonet.exceptions.OperationAbortedEx;
 import org.fao.geonet.index.Status;
 import org.fao.geonet.index.es.EsRestClient;
@@ -707,6 +701,22 @@ public class SiteApi {
         return ApplicationContextHolder.get().getBean(SystemInfo.class);
     }
 
+    @io.swagger.v3.oas.annotations.Operation(
+        summary = "Get notification levels",
+        description = "")
+    @RequestMapping(
+        path = "/info/notificationLevels",
+        produces = MediaType.APPLICATION_JSON_VALUE,
+        method = RequestMethod.GET)
+    @ResponseStatus(HttpStatus.OK)
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "List of notification levels.")
+    })
+    @PreAuthorize("hasAuthority('Administrator')")
+    @ResponseBody
+    public StatusValueNotificationLevel[] getNotificationLevel() {
+        return StatusValueNotificationLevel.values();
+    }
 
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Set catalog logo",

--- a/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
@@ -39,9 +39,13 @@ import org.fao.geonet.api.userfeedback.UserFeedbackUtils.RatingAverage;
 import org.fao.geonet.api.userfeedback.service.IUserFeedbackService;
 import org.fao.geonet.api.users.recaptcha.RecaptchaChecker;
 import org.fao.geonet.domain.AbstractMetadata;
+import org.fao.geonet.domain.StatusValueNotificationLevel;
+import org.fao.geonet.domain.User;
 import org.fao.geonet.domain.userfeedback.RatingCriteria;
 import org.fao.geonet.domain.userfeedback.RatingsSetting;
 import org.fao.geonet.domain.userfeedback.UserFeedback;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.metadata.DefaultStatusActions;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.repository.MetadataRepository;
@@ -65,8 +69,7 @@ import java.io.PrintWriter;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.fao.geonet.kernel.setting.Settings.SYSTEM_FEEDBACK_EMAIL;
-import static org.fao.geonet.kernel.setting.Settings.SYSTEM_SITE_NAME_PATH;
+import static org.fao.geonet.kernel.setting.Settings.*;
 
 
 /**
@@ -89,6 +92,9 @@ public class UserFeedbackAPI {
 
     @Autowired
     MetadataRepository metadataRepository;
+
+    @Autowired
+    IMetadataUtils metadataUtils;
 
     /**
      * Gets rating criteria
@@ -472,6 +478,40 @@ public class UserFeedbackAPI {
             userFeedbackService
                 .saveUserFeedback(UserFeedbackUtils.convertFromDto(userFeedbackDto, session != null ? session.getPrincipal() : null),
                     request.getRemoteAddr());
+
+
+            String notificationSetting = settingManager.getValue(SYSTEM_LOCALRATING_NOTIFICATIONLEVEL);
+            if (StringUtils.isNotEmpty(notificationSetting)) {
+                StatusValueNotificationLevel notificationLevel =
+                    StatusValueNotificationLevel.valueOf(notificationSetting);
+                if (notificationLevel != null) {
+                    List<User> userToNotify = DefaultStatusActions.getUserToNotify(notificationLevel,
+                        Collections.singleton(
+                            Integer.parseInt(
+                                metadataUtils.getMetadataId(userFeedbackDto.getMetadataUUID()))
+                        ),
+                        null);
+
+                    String catalogueName = settingManager.getValue(SYSTEM_SITE_NAME_PATH);
+                    String title = XslUtil.getIndexField(null, userFeedbackDto.getMetadataUUID(), "resourceTitle", "");
+
+                    List<String> toAddress = userToNotify.stream()
+                        .filter(u -> StringUtils.isNotEmpty(u.getEmail()))
+                        .map(User::getEmail)
+                        .collect(Collectors.toList());
+
+                    if (toAddress.size() > 0) {
+                        MailUtil.sendMail(toAddress,
+                            String.format(
+                                messages.getString("new_user_rating"),
+                                catalogueName, title),
+                            String.format(
+                                messages.getString("new_user_rating_text"),
+                                settingManager.getNodeURL(), userFeedbackDto.getMetadataUUID()),
+                            settingManager);
+                    }
+                }
+            }
 
             return new ResponseEntity(HttpStatus.CREATED);
         } catch (final Exception e) {

--- a/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
@@ -493,7 +493,7 @@ public class UserFeedbackAPI {
                         null);
 
                     String catalogueName = settingManager.getValue(SYSTEM_SITE_NAME_PATH);
-                    String title = XslUtil.getIndexField(null, userFeedbackDto.getMetadataUUID(), "resourceTitle", "");
+                    String title = XslUtil.getIndexField(null, userFeedbackDto.getMetadataUUID(), "resourceTitleObject", "");
 
                     List<String> toAddress = userToNotify.stream()
                         .filter(u -> StringUtils.isNotEmpty(u.getEmail()))
@@ -625,7 +625,7 @@ public class UserFeedbackAPI {
             }
         }
 
-        String title = XslUtil.getIndexField(null, metadataUuid, "resourceTitle", "");
+        String title = XslUtil.getIndexField(null, metadataUuid, "resourceTitleObject", "");
 
         MailUtil.sendMail(new ArrayList<>(toAddress),
             String.format(

--- a/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackUtils.java
@@ -200,7 +200,7 @@ public class UserFeedbackUtils {
             userfeedbackDto.setPublished(false);
         }
 
-        userfeedbackDto.setMetadataTitle(XslUtil.getIndexField(null, userfeedbackDto.getMetadataUUID(), "title", ""));
+        userfeedbackDto.setMetadataTitle(XslUtil.getIndexField(null, userfeedbackDto.getMetadataUUID(), "resourceTitleObject", ""));
 
         return userfeedbackDto;
     }

--- a/web-ui/src/main/resources/catalog/components/userfeedback/GnUserfeedbackDirective.js
+++ b/web-ui/src/main/resources/catalog/components/userfeedback/GnUserfeedbackDirective.js
@@ -428,7 +428,6 @@
         };
       }]);
 
-
   module.directive(
     'gnUserfeedbacklasthome', ['$http',
       function($http) {
@@ -440,23 +439,26 @@
           },
           templateUrl: '../../catalog/components/userfeedback/partials/userfeedbacklasthome.html',
           link: function(scope) {
-
+            var defaultSize = 6, increment = 6;
             scope.lastCommentsList = [];
-
-            scope.loadLastComments = function() {
+            scope.allCommentsLoaded = false;
+            scope.loadLastComments = function(size) {
               $http({
                 method: 'GET',
-                url: '../api/userfeedback?size=' + (scope.nbOfComments || 6),
+                url: '../api/userfeedback?size=' + size,
                 isArray: true
               }).then(function mySuccess(response) {
-                scope.lastCommentsList = [];
-                scope.lastCommentsList = scope.lastCommentsList.concat(response.data);
+                scope.allCommentsLoaded =
+                  response.data.length < size;
+                scope.lastCommentsList = response.data;
               }, function myError(response) {
                 console.log(response.statusText);
               });
-
             };
-            scope.loadLastComments();
+            scope.loadMore = function() {
+              scope.loadLastComments(scope.lastCommentsList.length + increment)
+            };
+            scope.loadLastComments(scope.nbOfComments || defaultSize);
           }
         };
       }]);

--- a/web-ui/src/main/resources/catalog/components/userfeedback/partials/userfeedbacklasthome.html
+++ b/web-ui/src/main/resources/catalog/components/userfeedback/partials/userfeedbacklasthome.html
@@ -2,7 +2,12 @@
   <div data-ng-show="lastCommentsList.length">
     <div class="gn-userfeedback-card"
       data-ng-repeat="row in lastCommentsList">
-      <div class="gn-userfeedback-pre-title" data-translate="">GUFfeedbackOn</div>
+      <div class="gn-userfeedback-pre-title">
+        <span data-translate="">GUFfeedbackOn</span>
+        <span data-ng-hide="row.published"> -
+          <strong data-translate="">GUFwaitingForApproval</strong>
+        </span>
+      </div>
       <a data-ng-href="#/metadata/{{row.metadataUUID}}">{{row.metadataTitle}}</a>
       <q class="gn-quote" data-ng-show="row.comment">{{row.comment}}</q>
       <div class="clearfix">
@@ -19,6 +24,10 @@
         </div>
       </div>
     </div>
+    <button class="btn btn-link"
+            data-ng-hide="allCommentsLoaded"
+            data-ng-click="loadMore()"
+            data-translate="">more</button>
   </div>
 
   <div data-ng-hide="lastCommentsList.length" data-translate="">GUFnoComments</div>

--- a/web-ui/src/main/resources/catalog/js/admin/DashboardController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/DashboardController.js
@@ -78,6 +78,11 @@
             label: 'versioning',
             icon: 'fa-rss',
             href: '#/dashboard/versioning'
+          }, {
+            type: 'feedbacks',
+            label: 'userFeedbackList',
+            icon: 'fa-comments',
+            href: '#/dashboard/feedbacks'
           }]};
 
       var dashboards = [{

--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -139,6 +139,11 @@
               $scope.systemInfo = data;
             });
 
+        $http.get('../api/site/info/notificationLevels')
+            .success(function(data) {
+              $scope.notificationLevels = data;
+            });
+
         // load log files
         $http.get('../api/site/logging')
             .success(function(data) {

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -955,6 +955,7 @@
     "system/userSelfRegistration/recaptcha/enable-help": "Enabling re-captcha will protect you and your users from spam and abuse. This is highly recommended when you enable feedback or self-registration. Create your re-captcha key on <a href='https://www.google.com/recaptcha/'>https://www.google.com/recaptcha/</a>",
     "system/userSelfRegistration/recaptcha/publickey": "Re-captcha public key",
     "system/userSelfRegistration/recaptcha/secretkey": "Re-captcha secret key",
+    "userFeedbackList": "Last user feedbacks",
     "system/userFeedback": "User feedback",
     "system/userFeedback/enable": "Enable feedback",
     "system/userFeedback/enable-help": "When enabled, make sure a mail server is also configured.",

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -212,6 +212,8 @@
   "usingCswFromNode": "Using portal CSW: ",
   "validateInspireUsingNode": "Remote INSPIRE validation using portal ",
   "noINSPIRETestTokenAvailable": "INSPIRE validator returned an empty token. Validation status can't be checked now. Check you configuration and API key or retry later.",
+  "system/localrating/notificationLevel": "Rating notification level",
+  "system/localrating/notificationLevel-help": "Define which users to alert in case of rating.",
   "system/inspire/remotevalidation/apikey": "API key",
   "system/inspire/remotevalidation/apikey-help": "Users and organisations interested in receiving an API key will need to contact the Validator team by sending an e-mail to JRC-INSPIRE-SUPPORT AT ec.europa.eu and provide the following information: name of the organisation, responsible contact point and intended use of the API key.",
   "system/inspire/remotevalidation/nodeid": "Portal identifier to use for the validation",

--- a/web-ui/src/main/resources/catalog/templates/admin/dashboard/feedbacks.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/dashboard/feedbacks.html
@@ -1,0 +1,10 @@
+<div class="row">
+  <div class="col-lg-12">
+    <div class="panel panel-default">
+      <div class="panel-heading" data-translate="">userFeedbackList</div>
+      <div class="panel-body">
+        <div data-gn-userfeedbacklasthome/>
+      </div>
+    </div>
+  </div>
+</div>

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
@@ -166,6 +166,12 @@
                               ng-selected="log.file === s.value">{{log.name}}
                       </option>
                     </select>
+                    <select data-ng-switch-when="system/localrating/notificationLevel" class="form-control"
+                            name="{{s.name}}">
+                      <option data-ng-repeat="l in notificationLevels" value="{{l}}"
+                              ng-selected="l === s.value">{{l}}
+                      </option>
+                    </select>
                     <select data-ng-switch-when="system/oai/mdmode" class="form-control"
                             name="{{s.name}}">
                       <option value="1"

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -612,6 +612,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/userFeedback/lastNotificationDate', '', 0, 1912, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/clickablehyperlinks/enable', 'true', 2, 2010, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/localrating/enable', 'advanced', 0, 2110, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/localrating/notificationLevel', 'catalogueAdministrator', 0, 2111, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/downloadservice/leave', 'false', 0, 2210, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/downloadservice/simple', 'true', 0, 2220, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/downloadservice/withdisclaimer', 'false', 0, 2230, 'y');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v406/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v406/migrate-default.sql
@@ -1,6 +1,7 @@
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/remotevalidation/nodeid', '', 0, 7212, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/remotevalidation/apikey', '', 0, 7213, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doipublicurl', '', 0, 100196, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/localrating/notificationLevel', 'catalogueAdministrator', 0, 2111, 'n');
 
 DELETE FROM Settings WHERE name = 'system/server/securePort';
 


### PR DESCRIPTION
When a user feedback is added it is hard for users to be aware of it.
Add an optional email notification to be configured in the settings with a notification level (like status change).

![image](https://user-images.githubusercontent.com/1701393/150478822-c8beabf0-9456-489e-a421-ac62afcf3626.png)

Add a new rudimentary panel in admin > information > last feedback to get a list of last user feedbacks.

![image](https://user-images.githubusercontent.com/1701393/150478732-8eebc1b8-f7b9-4e53-b761-9dd4e380449c.png)
