### PR TITLE
Editor / DOI check / Use doi.org.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -172,7 +172,7 @@
               {{resource.description | gnLocalized: lang}}
 
               <div data-ng-if="resource.lUrl !== null
-                               && resource.lUrl.match('/doi/') !== null"
+                               && resource.lUrl.match('doi.org') !== null"
                    data-gn-doi-wizard="gnCurrentEdit.uuid"
                    data-gn-doi-url="resource.lUrl"
                    data-xs-mode="true"></div>


### PR DESCRIPTION
Some user use old url like http://dx.doi.org/...


Maybe at some point we should use the DOI prefix ? but that suppose that all records are using it.