### PR TITLE
Map / Add WMS and metadata link

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1504,7 +1504,7 @@
                   };
 
                   var feedMdPromise =
-                    typeof md === 'object' ?
+                    md && typeof md === 'object' ?
                     $q.resolve(md).then(function(md) {
                       olL.set('md', md);
                     }) : (


### PR DESCRIPTION
`typeof null = object` avoid that case. Thanks Olivier for noticing this case in a project.