### PR TITLE
Harvester / CSW / After XSLT conversion check if the schema changed. 

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -308,6 +308,7 @@ public class Aligner extends BaseAligner<CswParams> {
         String mdUuid = ri.uuid;
         if (!params.xslfilter.equals("")) {
             md = processMetadata(context, md, processName, processParams);
+            schema = dataMan.autodetectSchema(md);
             // Get new uuid if modified by XSLT process
             mdUuid = metadataUtils.extractUUID(schema, md);
             if (mdUuid == null) {
@@ -439,8 +440,12 @@ public class Aligner extends BaseAligner<CswParams> {
             }
         }
 
+        boolean updateSchema = false;
         if (!params.xslfilter.equals("")) {
             md = processMetadata(context, md, processName, processParams);
+            String newSchema = dataMan.autodetectSchema(md);
+            updateSchema = !newSchema.equals(schema);
+            schema = newSchema;
         }
 
         applyBatchEdits(ri, md, schema);
@@ -455,11 +460,15 @@ public class Aligner extends BaseAligner<CswParams> {
 
         final AbstractMetadata metadata = metadataManager.updateMetadata(context, id, md, validate, ufo, index, language, ri.changeDate, true);
 
-        if (force) {
-            //change ownership of metadata to new harvester
-            metadata.getHarvestInfo().setUuid(params.getUuid());
-            metadata.getSourceInfo().setSourceId(params.getUuid());
-
+        if (force || updateSchema) {
+            if (force) {
+                //change ownership of metadata to new harvester
+                metadata.getHarvestInfo().setUuid(params.getUuid());
+                metadata.getSourceInfo().setSourceId(params.getUuid());
+            }
+            if (updateSchema) {
+                metadata.getDataInfo().setSchemaId(schema);
+            }
             metadataManager.save(metadata);
         }
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -872,7 +872,7 @@
 
       <xsl:for-each select="mdb:referenceSystemInfo/*">
         <xsl:for-each select="mrs:referenceSystemIdentifier/*">
-          <xsl:variable name="crs" select="mcc:code/*/text()"/>
+          <xsl:variable name="crs" select="mcc:code/*[1]/text()"/>
           <xsl:variable name="crsLabel"
                         select="if (mcc:description/*[1])
                                 then mcc:description/*[1]/text()
@@ -886,7 +886,7 @@
           </xsl:if>
 
           <crsDetails type="object">{
-            "code": "<xsl:value-of select="gn-fn-index:json-escape(mcc:code/*/text())"/>",
+            "code": "<xsl:value-of select="gn-fn-index:json-escape($crs)"/>",
             "codeSpace": "<xsl:value-of select="gn-fn-index:json-escape(mcc:codeSpace/*/text())"/>",
             "name": "<xsl:value-of select="gn-fn-index:json-escape($crsLabel)"/>",
             "url": "<xsl:value-of select="gn-fn-index:json-escape(mcc:code/*/@xlink:href)"/>"


### PR DESCRIPTION

If not extractUUID was failing because using the original schema.

Error was
```
2022-01-27T13:08:25,585+0100 ERROR [IGN_Geo_be] -    Record failed: 0fdbe090-bd35-41b1-8835-823eb769eaee. Error is: null
2022-01-27T13:08:25,585+0100 ERROR [IGN_Geo_be] - null
java.lang.NullPointerException
	at org.fao.geonet.utils.Xml.transform(Xml.java:384)
	at org.fao.geonet.kernel.datamanager.base.BaseMetadataUtils.extractUUID(BaseMetadataUtils.java:234)
	at org.fao.geonet.kernel.harvest.harvester.csw.Aligner.addMetadata(Aligner.java:312)
```