### PR TITLE
Formatter / Avoid exception on empty text

### DIFF
--- a/web/src/main/webapp/xslt/common/utility-tpl.xsl
+++ b/web/src/main/webapp/xslt/common/utility-tpl.xsl
@@ -69,10 +69,12 @@
           </xsl:copy>
         </xsl:for-each>
       </xsl:when>
-      <xsl:otherwise>
+      <xsl:when test="$txt != ''">
         <xsl:call-template name="addLineBreaksAndHyperlinksInternal">
           <xsl:with-param name="txt" select="$txt"/>
         </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>


### PR DESCRIPTION
```
Error on line 85 of utility-tpl.xsl:
  XPTY0004: An empty sequence is not allowed as the @select attribute of xsl:analyze-string
```