### PR TITLE
Editor / Associated resource / Better match and default in choices

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -663,6 +663,23 @@
                   scope.$watch('gnCurrentEdit.layerConfig', loadLayers);
                 };
 
+                var DEFAULT_CONFIG = {
+                  "process": "onlinesrc-add",
+                  "fields": {
+                    "url": {
+                      "isMultilingual": false
+                    },
+                    "protocol": {
+                      "isMultilingual": false
+                    },
+                    "name": {},
+                    "desc": {},
+                    "function": {
+                      "isMultilingual": false
+                    }
+                  }
+                };
+
                 // Check which config to load based on the link
                 // to edit properties. A match is returned based
                 // on link type and config process prefix. If none found
@@ -671,23 +688,39 @@
                   for (var i = 0; i < scope.config.types.length; i++) {
                     var c = scope.config.types[i];
                     var p = c.fields &&
-                            c.fields.protocol &&
-                            c.fields.protocol.value || '',
+                          c.fields.protocol &&
+                          c.fields.protocol.value || '',
                         f = c.fields &&
-                        c.fields.function &&
-                        c.fields.function.value || '',
+                          c.fields.function &&
+                          c.fields.function.value || '',
                         ap = c.fields &&
-                        c.fields.applicationProfile &&
-                        c.fields.applicationProfile.value || '';
-                    if (c.process.indexOf(link.type) === 0 &&
-                        p === (link.protocol || '') &&
-                        f === (link.function || '') &&
-                        ap === (link.applicationProfile || '')
+                          c.fields.applicationProfile &&
+                          c.fields.applicationProfile.value || '',
+                        nameFieldValue = c.fields &&
+                          c.fields.name &&
+                          c.fields.name.value || '',
+                        // Hardcoded name value in configuration
+                        // "fields": {...
+                        //   "name": {
+                        //     "value": "Other document",
+                        //     "hidden": true
+                        //   },
+                        isNameFieldHidden = c.fields &&
+                          c.fields.name && c.fields.name.hidden || false,
+                        hasSameProtocolFunctionAndAppProfile =
+                          c.process.indexOf(link.type) === 0 &&
+                          p === (link.protocol || '') &&
+                          f === (link.function || '') &&
+                          ap === (link.applicationProfile || '');
+                    if ((hasSameProtocolFunctionAndAppProfile && !isNameFieldHidden)
+                        || (hasSameProtocolFunctionAndAppProfile
+                            && isNameFieldHidden
+                            && nameFieldValue === (link.title[scope.lang] || ''))
                     ) {
                       return c;
                     }
                   }
-                  return scope.config.types[0];
+                  return DEFAULT_CONFIG;
                 }
 
                 gnOnlinesrc.register('onlinesrc', function(linkToEditOrType) {


### PR DESCRIPTION
When opening the add link popup, a check is done to find a corresponding match in the list of choices (see associated-panel/default.json).
If no match, the first one (ie. graphicOverview) was returned. Adding a DEFAULT_CONFIG which is more probably the most frequent case and avoid some errors on update.

![image](https://user-images.githubusercontent.com/1701393/152533787-d4843430-dadd-4fa8-a670-3e32e2a7df83.png)


Also some user force the name to fixed value (and hide that field). Use it in the matching process in case it is also relevant.

eg.
```json

      {
        "group": "documents",
        "label": "ProcessingAndValidation",
        "copyLabel": "name",
        "sources": {
          "filestore": true
        },
        "icon": "fa gn-icon-onlinesrc",
        "process": "onlinesrc-add",
        "fields": {
          "url": {
            "isMultilingual": false
          },
          "protocol": {
            "value": "WWW:LINK",
            "hidden": true,
            "isMultilingual": false
          },
          "name": {
            "value": "Processing and validation",
            "hidden": true
          },
          "desc": {},
          "function": {
            "value": "information",
            "hidden": true,
            "isMultilingual": false
          }
        }
      },
```