### PR TITLE
Standard / ISO19115-3 / Add online source / Create one link per CSV's name only for OGC

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/onlinesrc-add.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/onlinesrc-add.xsl
@@ -165,7 +165,7 @@
     <xsl:if test="$url">
       <!-- If a name is provided loop on all languages -->
       <xsl:choose>
-        <xsl:when test="contains($name, ',')">
+        <xsl:when test="starts-with($protocol, 'OGC:') and contains($name, ',')">
           <xsl:for-each select="tokenize($name, ',')">
             <mrd:onLine>
               <cit:CI_OnlineResource>


### PR DESCRIPTION
If the name of a link was containing some "," then it was creating on link per elements. 
This only applies to a list of layer names in OGC service.