### PR TITLE
MetadataResourceDatabaseMigration / Catalogue editing harvested records may require this

### DIFF
--- a/core/src/main/java/org/fao/geonet/MetadataResourceDatabaseMigration.java
+++ b/core/src/main/java/org/fao/geonet/MetadataResourceDatabaseMigration.java
@@ -170,15 +170,17 @@ public class MetadataResourceDatabaseMigration extends DatabaseMigrationTask {
     public void update(Connection connection) throws SQLException {
         Log.debug(Geonet.DB, "MetadataResourceDatabaseMigration");
 
+        final SettingManager settingManager = applicationContext.getBean(SettingManager.class);
+
         try (PreparedStatement update = connection.prepareStatement(
             "UPDATE metadata SET data=? WHERE id=?")
         ) {
             try (Statement statement = connection.createStatement();
-                 ResultSet resultSet = statement.executeQuery(
-                     "SELECT data,id,uuid FROM metadata WHERE isharvested = 'n'")
+                 ResultSet resultSet = statement.executeQuery(String.format(
+                     "SELECT data, id, uuid FROM metadata WHERE data LIKE '%%%s%%'",
+                     settingManager.getServerURL()))
             ) {
                 int numInBatch = 0;
-                final SettingManager settingManager = applicationContext.getBean(SettingManager.class);
 
                 while (resultSet.next()) {
                     final Element xml = Xml.loadString(resultSet.getString(1), false);


### PR DESCRIPTION


When a catalogue allows editing harvested records, it may contains URLs which needs to be updated. In some situation, harvested records are not updated anymore by the harvester but still needs to have valid URL to thumbnails and attachments.

Instead of excluding non harvested records, process all records which have references to the server URL.

Note: If needed before processing on a copy of the database, always update the server URL to match the current node you are working with:
```sql
UPDATE metadata SET data = replace(data,
  'http://onegeology-geonetwork.brgm.fr/geonetwork3',
  'http://localhost:8080/geonetwork')
  WHERE data LIKE '%http://onegeology-geonetwork.brgm.fr/geonetwork3%';
```
and then run the migration step.