### PR TITLE
Directory / Add search configuration and ZIP export

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/mef/MEF2Exporter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/MEF2Exporter.java
@@ -230,9 +230,6 @@ class MEF2Exporter {
         String id = "" + record.getId();
         String isTemp = record.getDataInfo().getType().codeString;
 
-        if (!"y".equals(isTemp) && !"n".equals(isTemp))
-            throw new Exception("Cannot export sub template");
-
         final Path metadataXmlDir = metadataRootDir.resolve(MD_DIR);
         Files.createDirectories(metadataXmlDir);
 

--- a/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
+++ b/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
@@ -44,12 +44,12 @@
         'gnEditor', 'gnSchemaManagerService',
         'gnEditorXMLService', 'gnHttp', 'gnConfig',
         'gnCurrentEdit', 'gnConfigService', 'gnPopup',
-        'gnGlobalSettings', 'gnUrlUtils',
+        'gnGlobalSettings', 'gnSearchSettings', 'gnUrlUtils',
         function($rootScope, $timeout, $q, $http, $translate,
                  gnEditor, gnSchemaManagerService,
                  gnEditorXMLService, gnHttp, gnConfig,
                  gnCurrentEdit, gnConfigService, gnPopup,
-       gnGlobalSettings, gnUrlUtils) {
+       gnGlobalSettings, gnSearchSettings, gnUrlUtils) {
 
           return {
             restrict: 'A',
@@ -98,6 +98,8 @@
             compile: function compile(tElement, tAttrs, transclude) {
               return {
                 pre: function preLink(scope) {
+                  var directorySearchSettings = gnGlobalSettings.gnCfg.mods.directory || {};
+
                   scope.searchObj = {
                     any: '',
                     internal: true,
@@ -108,9 +110,12 @@
                       from: 1,
                       to: 20,
                       root: 'gmd:CI_ResponsibleParty',
-                      sortBy: 'resourceTitleObject.default.keyword',
+                      sortBy: directorySearchSettings.sortBy
+                        || gnSearchSettings.sortBy,
                       sortOrder: '',
-                      resultType: 'subtemplates'
+                      resultType: 'subtemplates',
+                      queryBase: directorySearchSettings.queryBase
+                        || gnSearchSettings.queryBase
                     }
                   };
 
@@ -522,8 +527,8 @@
         }]);
 
   module.directive('gnDirectoryEntryListSelector',
-      ['gnGlobalSettings',
-       function(gnGlobalSettings) {
+      ['gnGlobalSettings', 'gnSearchSettings',
+       function(gnGlobalSettings, gnSearchSettings) {
          return {
            restrict: 'A',
            templateUrl: '../../catalog/components/edit/' +
@@ -533,6 +538,8 @@
            compile: function compile(tElement, tAttrs, transclude) {
              return {
                pre: function preLink(scope) {
+                 var directorySearchSettings = gnGlobalSettings.gnCfg.mods.directory || {};
+
                  scope.searchObj = {
                    internal: true,
                    configId: 'directoryInEditor',
@@ -542,8 +549,9 @@
                      from: 1,
                      to: 10,
                      root: 'gmd:CI_ResponsibleParty',
-                     sortBy: 'resourceTitleObject.default.keyword',
-                     sortOrder: ''
+                     sortBy: directorySearchSettings.sortBy || gnSearchSettings.sortBy,
+                     queryBase: directorySearchSettings.queryBase
+                       || gnSearchSettings.queryBase
                    }
                  };
                  if(scope.$eval(tAttrs['showValidOnly'])) {

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
@@ -149,7 +149,7 @@
         var excludeFields = ['_content_type', 'fast', 'from', 'to', 'bucket',
           'sortBy', 'sortOrder', 'resultType', 'facet.q', 'any', 'geometry', 'query_string',
           'creationDateFrom', 'creationDateTo', 'dateFrom', 'dateTo', 'geom', 'relation',
-          'editable'];
+          'editable', 'queryBase'];
         if(p.any || luceneQueryString) {
           var queryStringParams = [];
           if (p.any) {
@@ -157,7 +157,8 @@
             var queryExpression = p.any.match(/^q\((.*)\)$/);
             if (queryExpression == null) {
               // var queryBase = '${any} resourceTitleObject.default:(${any})^2',
-              var queryBase = '(' + gnGlobalSettings.gnCfg.mods.search.queryBase + ')',
+              var queryBase = '(' +
+                  (p.queryBase || gnGlobalSettings.gnCfg.mods.search.queryBase) + ')',
                 defaultQuery = '${any}';
               if (queryBase.indexOf(defaultQuery) === -1) {
                 console.warn('Check your configuration. Query base \'' +

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
@@ -165,14 +165,14 @@
       </li>
 
 
-      <li data-ng-if="collectionTemplates && collectionTemplates.length > 0"
+      <li data-ng-if="!excludePattern.test('collection') && collectionTemplates && collectionTemplates.length > 0"
           class="divider"></li>
-      <li data-ng-if="collectionTemplates && collectionTemplates.length > 0"
+      <li data-ng-if="!excludePattern.test('collection') && collectionTemplates && collectionTemplates.length > 0"
           class="dropdown-header">
         <i class="fa fa-fw gn-icon-series"></i>&nbsp;
         <span translate>createCollectionFromSelectionAs</span>
       </li>
-      <li data-ng-if="collectionTemplates"
+      <li data-ng-if="!excludePattern.test('collection') && collectionTemplates"
           data-ng-repeat="c in collectionTemplates">
         <a href="" data-ng-click="createCollection(c)">
           <span translate>{{c.resourceTitle}}</span>

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -828,29 +828,29 @@ goog.require('gn_alert');
                 'size': 2
               }
             }
-          },
-          'directory': {
-            'sortbyValues': [{
-              'sortBy': 'relevance',
-              'sortOrder': ''
-            }, {
-              'sortBy': 'dateStamp',
-              'sortOrder': 'desc'
-            }, {
-              'sortBy': 'resourceTitleObject.default.keyword',
-              'sortOrder': ''
-            }, {
-              'sortBy': 'recordOwner',
-              'sortOrder': ''
-            }, {
-              'sortBy': 'valid',
-              'sortOrder': 'desc'
-            }],
-            'sortBy': 'relevance',
-            // Add some fuzziness when search on directory entries
-            // but boost exact match.
-            'queryBase': 'any.${searchLang}:(${any}) any.common:(${any}) resourceTitleObject.${searchLang}:"${any}"^10 resourceTitleObject.${searchLang}:(${any})^5 resourceTitleObject.${searchLang}:(${any}~2)'
           }
+        },
+        'directory': {
+          'sortbyValues': [{
+            'sortBy': 'relevance',
+            'sortOrder': ''
+          }, {
+            'sortBy': 'dateStamp',
+            'sortOrder': 'desc'
+          }, {
+            'sortBy': 'resourceTitleObject.default.keyword',
+            'sortOrder': ''
+          }, {
+            'sortBy': 'recordOwner',
+            'sortOrder': ''
+          }, {
+            'sortBy': 'valid',
+            'sortOrder': 'desc'
+          }],
+          'sortBy': 'relevance',
+          // Add some fuzziness when search on directory entries
+          // but boost exact match.
+          'queryBase': 'any.${searchLang}:(${any}) any.common:(${any}) resourceTitleObject.${searchLang}:"${any}"^10 resourceTitleObject.${searchLang}:(${any})^5 resourceTitleObject.${searchLang}:(${any}~2)'
         },
         'admin': {
           'enabled': true,

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -828,6 +828,28 @@ goog.require('gn_alert');
                 'size': 2
               }
             }
+          },
+          'directory': {
+            'sortbyValues': [{
+              'sortBy': 'relevance',
+              'sortOrder': ''
+            }, {
+              'sortBy': 'dateStamp',
+              'sortOrder': 'desc'
+            }, {
+              'sortBy': 'resourceTitleObject.default.keyword',
+              'sortOrder': ''
+            }, {
+              'sortBy': 'recordOwner',
+              'sortOrder': ''
+            }, {
+              'sortBy': 'valid',
+              'sortOrder': 'desc'
+            }],
+            'sortBy': 'relevance',
+            // Add some fuzziness when search on directory entries
+            // but boost exact match.
+            'queryBase': 'any.${searchLang}:(${any}) any.common:(${any}) resourceTitleObject.${searchLang}:"${any}"^10 resourceTitleObject.${searchLang}:(${any})^5 resourceTitleObject.${searchLang}:(${any}~2)'
           }
         },
         'admin': {

--- a/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
@@ -61,6 +61,7 @@
     'gnMetadataManager',
     'gnMetadataActions',
     'gnGlobalSettings',
+    'gnSearchSettings',
     'gnConfig',
     'gnConfigService',
     function($scope, $routeParams, $http,
@@ -73,6 +74,7 @@
         gnMetadataManager,
         gnMetadataActions,
         gnGlobalSettings,
+        gnSearchSettings,
         gnConfig,
         gnConfigService) {
 
@@ -95,34 +97,24 @@
       $scope.mdList = null;
       $scope.activeType = null;
       $scope.activeEntry = null;
+
+      var directorySearchSettings = gnGlobalSettings.gnCfg.mods.editor.directory;
+
       $scope.defaultSearchObj = {
         selectionBucket: 'd101',
         configId: 'directory',
         any: '',
         params: {
-          sortBy: 'resourceTitleObject.default.keyword',
+          sortBy: directorySearchSettings.sortBy
+            || gnSearchSettings.sortBy,
           isTemplate: ['s'],
           from: 1,
-          to: 20
+          to: 20,
+          queryBase: directorySearchSettings.queryBase
+            || gnSearchSettings.queryBase
         },
-        sortbyValues: [
-          {
-            sortBy: 'resourceTitleObject.default.keyword',
-            sortOrder: ''
-          },
-          {
-            sortBy: 'recordOwner',
-            sortOrder: ''
-          },
-          {
-            sortBy: 'dateStamp',
-            sortOrder: 'desc'
-          },
-          {
-            sortBy: 'valid',
-            sortOrder: ''
-          }
-        ]
+        sortbyValues: directorySearchSettings.sortbyValues
+          || gnSearchSettings.sortbyValues
       };
 
       $scope.searchObj = angular.extend({}, $scope.defaultSearchObj);

--- a/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
@@ -98,7 +98,7 @@
       $scope.activeType = null;
       $scope.activeEntry = null;
 
-      var directorySearchSettings = gnGlobalSettings.gnCfg.mods.editor.directory;
+      var directorySearchSettings = gnGlobalSettings.gnCfg.mods.directory || {};
 
       $scope.defaultSearchObj = {
         selectionBucket: 'd101',

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -73,6 +73,8 @@
   "sortBy-resourceTitleObject.default.keyword": "title",
   "sortBy-relevance": "relevancy",
   "sortBy-rating": "rating",
+  "sortBy-valid": "validation status",
+  "sortBy-recordOwner": "owner",
   "csw-sortByHelp": "Define sort option for GetRecords query. This can solve issue for large sets where some records may change on the remote node during harvesting and returned in different pages. Sorting by 'identifier:A' means by UUID with alphabetical order. Any CSW queryables can be used in combination with A or D for setting the ordering.",
   "moreLikeThis": "Similar records",
   "onTheWeb": "More online information",

--- a/web-ui/src/main/resources/catalog/templates/editor/directory.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/directory.html
@@ -136,7 +136,7 @@
 
               <div class="col-xs-6 col-lg-4 col-lg-pull-5">
                 <div class="" data-gn-selection-widget=""
-                    data-exclude-actions-pattern="export*|validate|updateCategories"
+                    data-exclude-actions-pattern="exportPDF|exportCSV|collection|validate|updateCategories"
                     data-results="searchResults"></div>
               </div>
 


### PR DESCRIPTION
Currently same base query was used to search for records and directory entries. In most cases, directory is used for contact and organisation and the default base query may not be a good choice for such search. Language analysis is not really necessary for individual names.

This adds the possibility to customize the search for directory search and by default add some kind of fuzziness for not exact match/typo while boosting exact match. This sounds more relevant than using '*' like in GN3.


![image](https://user-images.githubusercontent.com/1701393/154904478-f1f7f831-12cf-459b-be49-bf7c03c38cd6.png)
