### PR TITLE
Directory / Fix editing subtemplate

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -139,7 +139,9 @@
          return {
            buildEditUrlPrefix: function(service) {
              var params = ['../api/records/',
-               gnCurrentEdit.metadata.uuid, '/', service, '?'];
+               gnCurrentEdit.metadata
+                 ? gnCurrentEdit.metadata.uuid : gnCurrentEdit.id,
+               '/', service, '?'];
              gnCurrentEdit.tab ?
              params.push('&currTab=', gnCurrentEdit.tab) :
              params.push('&currTab=', 'default');


### PR DESCRIPTION
For subtemplate we don't query the search service first so we don't have the corresponding index object. Still use the internal id for now.