### PR TITLE
Search / Facet / Load more buckets preserve filters

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -510,7 +510,8 @@
         request.query,
         facet.path,
         facet.items.length + (moreItemsNumber || 20),
-        undefined, undefined,
+        facet.include || undefined,
+        facet.exclude || undefined,
         facetConfigs
         );
     }


### PR DESCRIPTION
When loading more buckets, the filter was not took into account.


![image](https://user-images.githubusercontent.com/1701393/154307218-4382d212-d0a7-4601-ade1-91a4a719daaa.png)
