### PR TITLE
Map / WFS / Failed to load layer when feature type has no prefix

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1310,32 +1310,22 @@
                     version: getCapLayer.version,
                     srsName: map.getView().getProjection().getCode(),
                     bbox: extent.join(',')
-                  };
+                  }, typename =
+                      (getCapLayer.name.prefix.length > 0 ?
+                        (getCapLayer.name.prefix + ':') : '')
+                      + getCapLayer.name.localPart;
 
-                  if (parametersMap.version < "2.0.0") {
-                    parametersMap.typeName = getCapLayer.name.prefix + ':' +
-                      getCapLayer.name.localPart;
-                  } else {
-                    parametersMap.typeNames = getCapLayer.name.prefix + ':' +
-                      getCapLayer.name.localPart;
+                  parametersMap[parametersMap.version < "2.0.0"
+                    ? 'typeName' : 'typeNames'] = typename;
+
+                  //Fix, ArcGIS fails if there is a bbox:
+                  // TODO: A better ArcGIS check could be better?
+                  if(getCapLayer.version == '1.1.0') {
+                    delete parametersMap.bbox;
                   }
 
                   var urlGetFeature = gnUrlUtils.append(parts[0],
                       gnUrlUtils.toKeyValue(parametersMap));
-
-                  //Fix, ArcGIS fails if there is a bbox:
-                  if(getCapLayer.version == '1.1.0') {
-                    urlGetFeature = gnUrlUtils.append(parts[0],
-                        gnUrlUtils.toKeyValue({
-                          service: 'WFS',
-                          request: 'GetFeature',
-                          version: getCapLayer.version,
-                          srsName: map.getView().getProjection().getCode(),
-                          typeName: getCapLayer.name.prefix + ':' +
-                                     getCapLayer.name.localPart}));
-                  }
-
-
 
                   //If this goes through the proxy, don't remove parameters
                   if(getCapLayer.useProxy


### PR DESCRIPTION
eg. map > add layer > from WFS service http://www.ifremer.fr/services/wfs/nouvelle_caledonie?SERVICE=WFS&REQUEST=GetCapabilities

Will make a query
http://www.ifremer.fr/services/wfs/nouvelle_caledonie?service=WFS&request=GetFeature&version=1.1.0&srsName=EPSG:3857&typeName=:IFR_NEW_CAL_Q2_ZONES_MARINES_NC_RGNC
which fails with `TypeName ':IFR_NEW_CAL_Q2_ZONES_MARINES_NC_RGNC' unknow`

Note: there is also a weird check for //Fix, ArcGIS fails if there is a bbox: