### PR TITLE
UI config / Search results / Open choice for contact field to use

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -886,11 +886,23 @@
 
               <div data-ng-switch-when="searchResultContact">
                 <label class="control-label">{{('ui-' + key) | translate}}</label>
-                <select class="form-control"
-                        id="ui-searchResultContact-{{$index}}"
-                        data-ng-options="o | translate for o in searchResultContactChoices"
-                        data-ng-model="mCfg[key]">
-                </select>
+                <div class="input-group">
+                  <input class="form-control"
+                         id="ui-searchResultContact-{{$index}}"
+                         data-ng-model="mCfg[key]"/>
+                  <div class="input-group-btn">
+                    <div class="btn-group">
+                      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <span class="caret"></span>
+                      </button>
+                      <ul class="dropdown-menu dropdown-menu-right">
+                        <li data-ng-repeat="o in searchResultContactChoices">
+                          <a href="" data-ng-click="mCfg[key] = o">{{o | translate}} ({{o}})</a>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
                 <p class="help-block"
                    data-ng-init="helpKey = 'ui-' + key + '-help'"
                    data-ng-show="(helpKey | translate) != helpKey"


### PR DESCRIPTION
Follow https://github.com/titellus/core-geonetwork/pull/127/commits/cced47b4c7162bc5d21511b55a0fb1bb3bb32fd6

'Org', 'OrgForResource', 'OrgForDistribution' are the main index field than can be used but some users may want to be more precise by defining a role eg. 'pointOfContactOrgForResource'. Allow free text and suggest default choices.

![image](https://user-images.githubusercontent.com/1701393/155287949-344d128e-e92b-4f98-b474-d35a2e6be5bc.png)
