### PR TITLE
Search / Add specific configuration for each query types and add query_string options

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -143,7 +143,7 @@
                   ui-addWMSLayersToMap-urlLayerParam-help</p>
               </div>
 
-              <div data-ng-switch-when="autocompleteConfig|moreLikeThisConfig|facetConfig|relatedFacetConfig|filters|scoreConfig|collectionTableConfig|distributionConfig"
+              <div data-ng-switch-when="autocompleteConfig|moreLikeThisConfig|facetConfig|relatedFacetConfig|filters|scoreConfig|queryBaseOptions|collectionTableConfig|distributionConfig"
                    data-ng-switch-when-separator="|">
                 <label class="control-label">{{('ui-' + key) | translate}}</label>
                 <gn-json-edit height="300" model="mCfg[key]"></gn-json-edit>

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
@@ -197,12 +197,15 @@
             queryStringParams.push(luceneQueryString);
           }
 
-          queryHook.must.push({
+          var queryString = {
             query_string: {
-              // minimum_should_match: '70%',
               query: queryStringParams.join(' AND ').trim()
             }
-          });
+          };
+
+          angular.extend(queryString.query_string,
+            gnGlobalSettings.gnCfg.mods.search.queryBaseOptions || {});
+          queryHook.must.push(queryString);
         }
         // ranges criteria (for dates)
         if (p.creationDateFrom || p.creationDateTo) {

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
@@ -154,12 +154,26 @@
           var queryStringParams = [];
           if (p.any) {
             p.any = p.any.toString();
-            var queryExpression = p.any.match(/^q\((.*)\)$/);
+
+            var defaultQuery = '${any}',
+              queryExpression = p.any.match(/^q\((.*)\)$/);
+
             if (queryExpression == null) {
               // var queryBase = '${any} resourceTitleObject.default:(${any})^2',
-              var queryBase = '(' +
-                  (p.queryBase || gnGlobalSettings.gnCfg.mods.search.queryBase) + ')',
-                defaultQuery = '${any}';
+              var queryBase = "";
+              if (p.queryBase) { // Force a query
+                queryBase = p.queryBase;
+              } else if (state.exactMatch === true && state.titleOnly === true) {
+                queryBase = gnGlobalSettings.gnCfg.mods.search.queryTitleExactMatch;
+              } else if (state.exactMatch === true) {
+                queryBase = gnGlobalSettings.gnCfg.mods.search.queryExactMatch;
+              } else if (state.titleOnly === true) {
+                queryBase = gnGlobalSettings.gnCfg.mods.search.queryTitle;
+              } else {
+                queryBase = gnGlobalSettings.gnCfg.mods.search.queryBase
+              }
+              queryBase = '(' + queryBase + ')';
+
               if (queryBase.indexOf(defaultQuery) === -1) {
                 console.warn('Check your configuration. Query base \'' +
                   queryBase + '\' MUST contains a \'${any}\' token ' +
@@ -171,13 +185,8 @@
 
               var languageConfig = getLanguageConfig(p.any, state),
                 searchString = escapeSpecialCharacters(p.any),
-                q = injectLanguage(state.titleOnly
-                  ? gnGlobalSettings.gnCfg.mods.search.queryTitle
-                  : queryBase, languageConfig, true)
-                  .replace(
-                  /\$\{any\}/g,
-                  state.exactMatch === true
-                              ? '\"' + searchString + '\"' : searchString);
+                q = injectLanguage(queryBase, languageConfig, true)
+                      .replace(/\$\{any\}/g, searchString);
               queryStringParams.push(q);
             } else {
               queryStringParams.push(queryExpression[1]);
@@ -190,6 +199,7 @@
 
           queryHook.must.push({
             query_string: {
+              // minimum_should_match: '70%',
               query: queryStringParams.join(' AND ').trim()
             }
           });

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -219,9 +219,13 @@ goog.require('gn_alert');
                 "filter": { "exists": { "field": "parentUuid" } },
                 "weight": 0.3
               },
-              // Boost down obsolete records
+              // Boost down obsolete and superseded records
               {
                 "filter": { "match": { "cl_status.key": "obsolete" } },
+                "weight": 0.2
+              },
+              {
+                "filter": { "match": { "cl_status.key": "superseded" } },
                 "weight": 0.3
               },
               // {

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -768,21 +768,14 @@ goog.require('gn_alert');
           'editorIndentType': '',
           'allowRemoteRecordLink': true,
           'facetConfig': {
-            'cl_hierarchyLevel.key': {
+            'resourceType': {
               'terms': {
-                'field': 'cl_hierarchyLevel.key',
-                'size': 20
+                'field': 'resourceType'
               }
             },
             'cl_status.key': {
               'terms': {
                 'field': 'cl_status.key',
-                'size': 15
-              }
-            },
-            'sourceCatalogue': {
-              'terms': {
-                'field': 'sourceCatalogue',
                 'size': 15
               }
             },
@@ -796,48 +789,91 @@ goog.require('gn_alert');
               'terms': {
                 'field': 'valid_inspire',
                 'size': 10
+              },
+              'meta': {
+                'collapsed': true
+              }
+            },
+            'sourceCatalogue': {
+              'terms': {
+                'field': 'sourceCatalogue',
+                'size': 100,
+                'include': '.*'
+              },
+              'meta': {
+                'orderByTranslation': true,
+                'filterByTranslation': true,
+                'displayFilter': true,
+                'collapsed': true
               }
             },
             'groupOwner': {
               'terms': {
                 'field': 'groupOwner',
-                'size': 10
+                'size': 200,
+                'include': '.*'
+              },
+              'meta': {
+                'orderByTranslation': true,
+                'filterByTranslation': true,
+                'displayFilter': true,
+                'collapsed': true
               }
             },
             'recordOwner': {
               'terms': {
                 'field': 'recordOwner',
-                'size': 10
-              }
-            },
-            'groupPublishedId': {
-              'terms': {
-                'field': 'groupPublishedId',
-                'size': 10
-              }
-            },
-            'documentStandard': {
-              'terms': {
-                'field': 'documentStandard',
-                'size': 10
-              }
-            },
-            'isHarvested': {
-              'terms': {
-                'field': 'isHarvested',
-                'size': 2
-              }
-            },
-            'isTemplate': {
-              'terms': {
-                'field': 'isTemplate',
-                'size': 5
+                'size': 5,
+                'include': '.*'
+              },
+              'meta': {
+                'collapsed': true
               }
             },
             'isPublishedToAll': {
               'terms': {
                 'field': 'isPublishedToAll',
                 'size': 2
+              }
+            },
+            'groupPublishedId': {
+              'terms': {
+                'field': 'groupPublishedId',
+                'size': 200,
+                'include': '.*'
+              },
+              'meta': {
+                'orderByTranslation': true,
+                'filterByTranslation': true,
+                'displayFilter': true,
+                'collapsed': true
+              }
+            },
+            'documentStandard': {
+              'terms': {
+                'field': 'documentStandard',
+                'size': 10
+              },
+              'meta': {
+                'collapsed': true
+              }
+            },
+            'isHarvested': {
+              'terms': {
+                'field': 'isHarvested',
+                'size': 2
+              },
+              'meta': {
+                'collapsed': true
+              }
+            },
+            'isTemplate': {
+              'terms': {
+                'field': 'isTemplate',
+                'size': 5
+              },
+              'meta': {
+                'collapsed': true
               }
             }
           }

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -148,13 +148,17 @@ goog.require('gn_alert');
           // 'queryBase': '${any}',
           // Full text but more boost on title match
           // * Search in languages depending on the strategy selected
-          'queryBase': 'any.${searchLang}:(${any}) any.common:(${any}) resourceTitleObject.${searchLang}:(${any})^2',
+          'queryBase': 'any.${searchLang}:(${any}) any.common:(${any}) resourceTitleObject.${searchLang}:(${any})^2 resourceTitleObject.${searchLang}:\"${any}\"^6',
+          // TODO: Exact match should not even analyze
+          // so we could create an exact field not analyzed in the index maybe?
+          'queryExactMatch': 'any.${searchLang}:\"${any})\" any.common:\"${any}\" resourceTitleObject.${searchLang}:\"${any}\"^2',
           // * Force UI language - in this case set languageStrategy to searchInUILanguage
           // and disable language options in searchOptions
           // 'queryBase': 'any.${uiLang}:(${any}) any.common:(${any}) resourceTitleObject.${uiLang}:(${any})^2',
           // * Search in French fields (with french analysis)
           // 'queryBase': 'any.langfre:(${any}) any.common:(${any}) resourceTitleObject.langfre:(${any})^2',
           'queryTitle': 'resourceTitleObject.${searchLang}:(${any})',
+          'queryTitleExactMatch': 'resourceTitleObject.${searchLang}:"${any}"',
           'searchOptions': {
             titleOnly: true,
             exactMatch: true,
@@ -245,8 +249,8 @@ goog.require('gn_alert');
                     "query": "",
                     "type": "bool_prefix",
                     "fields": [
-                      "resourceTitleObject.${searchLang}",
-                      "resourceAbstractObject.${searchLang}",
+                      "resourceTitleObject.${searchLang}^6",
+                      "resourceAbstractObject.${searchLang}^.5",
                       "tag",
                       "resourceIdentifier"
                       // "anytext",

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -148,20 +148,20 @@ goog.require('gn_alert');
           // 'queryBase': '${any}',
           // Full text but more boost on title match
           // * Search in languages depending on the strategy selected
-          'queryBase': 'any.${searchLang}:(${any}) OR any.common:(${any}) OR resourceTitleObject.${searchLang}:(${any})^2 OR resourceTitleObject.${searchLang}:\"${any}\"^6',
+          'queryBase': 'any.${searchLang}:(${any}) OR any.common:(${any}) OR resourceTitleObject.${searchLang}:(${any})^2 OR resourceTitleObject.\\*:\"${any}\"^6',
           'queryBaseOptions': {
             'default_operator': 'AND'
           },
           // TODO: Exact match should not even analyze
           // so we could create an exact field not analyzed in the index maybe?
-          'queryExactMatch': 'any.${searchLang}:\"${any})\" OR any.common:\"${any}\" OR resourceTitleObject.${searchLang}:\"${any}\"^2',
+          'queryExactMatch': 'any.${searchLang}:\"${any})\" OR any.common:\"${any}\" OR resourceTitleObject.\\*:\"${any}\"^2',
           // * Force UI language - in this case set languageStrategy to searchInUILanguage
           // and disable language options in searchOptions
           // 'queryBase': 'any.${uiLang}:(${any}) any.common:(${any}) resourceTitleObject.${uiLang}:(${any})^2',
           // * Search in French fields (with french analysis)
           // 'queryBase': 'any.langfre:(${any}) any.common:(${any}) resourceTitleObject.langfre:(${any})^2',
-          'queryTitle': 'resourceTitleObject.${searchLang}:(${any})',
-          'queryTitleExactMatch': 'resourceTitleObject.${searchLang}:"${any}"',
+          'queryTitle': 'resourceTitleObject.\\*:(${any})',
+          'queryTitleExactMatch': 'resourceTitleObject.\\*:"${any}"',
           'searchOptions': {
             titleOnly: true,
             exactMatch: true,

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -148,10 +148,13 @@ goog.require('gn_alert');
           // 'queryBase': '${any}',
           // Full text but more boost on title match
           // * Search in languages depending on the strategy selected
-          'queryBase': 'any.${searchLang}:(${any}) any.common:(${any}) resourceTitleObject.${searchLang}:(${any})^2 resourceTitleObject.${searchLang}:\"${any}\"^6',
+          'queryBase': 'any.${searchLang}:(${any}) OR any.common:(${any}) OR resourceTitleObject.${searchLang}:(${any})^2 OR resourceTitleObject.${searchLang}:\"${any}\"^6',
+          'queryBaseOptions': {
+            'default_operator': 'AND'
+          },
           // TODO: Exact match should not even analyze
           // so we could create an exact field not analyzed in the index maybe?
-          'queryExactMatch': 'any.${searchLang}:\"${any})\" any.common:\"${any}\" resourceTitleObject.${searchLang}:\"${any}\"^2',
+          'queryExactMatch': 'any.${searchLang}:\"${any})\" OR any.common:\"${any}\" OR resourceTitleObject.${searchLang}:\"${any}\"^2',
           // * Force UI language - in this case set languageStrategy to searchInUILanguage
           // and disable language options in searchOptions
           // 'queryBase': 'any.${uiLang}:(${any}) any.common:(${any}) resourceTitleObject.${uiLang}:(${any})^2',
@@ -969,7 +972,8 @@ goog.require('gn_alert');
         'internalThesaurus',
         'locationThesaurus',
         'distributionConfig',
-        'collectionTableConfig'
+        'collectionTableConfig',
+        'queryBaseOptions'
       ],
       current: null,
       isDisableLoginForm: false,


### PR DESCRIPTION
Currently a baseQuery is defined and if exact match is set, then the search string is quoted.
This makes difficult to give more weight to an exact match in the main base query.
eg. with "resourceTitleObject.${searchLang}:\"${any}\"^6"

A catalogue with quite common terms like "reference grid" will not necessarily present first records with one of those 2 words in the title.

Add specific queries for each types:
* full text ie. queryBase
* exact match ie. queryExactMatch (new)
* title search ie. queryTitle
* exact title match ie. queryTitleExactMatch (new)

Also give more weight on title for suggestion and less on abstract.

Boost by status. Obsolete records are even less important than superseded ones. A general approach in catalogues is to have old records declared as obsolete, the last version is superseded.


Before

![image](https://user-images.githubusercontent.com/1701393/155316218-17f17841-12c8-45ad-9d61-0c65cad825d5.png)


After 

![image](https://user-images.githubusercontent.com/1701393/155316127-bcda845e-4b7f-4b8e-b8f3-4ed93ec5f3c6.png)



Add support for query_string options eg. default_operator
See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-top-level-params


Editor board / Improve facet list (ordering, collapsed, filtering for large lists)
![image](https://user-images.githubusercontent.com/1701393/159902814-26d7e0f3-73e5-456d-9aff-47d1ea423a49.png)


Note: 
* exact match is currently not totally exact as we go through the analysis phase - so this can be improved in future work.
* minimum_should_match is also maybe an option which can be useful. Needs more experiments