### PR TITLE
Standard / ISO19115-3 / To ISO19139 / Better aggregate mapping

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/toISO19139.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/toISO19139.xsl
@@ -87,7 +87,7 @@
       <xsl:variable name="nameSpacePrefix">
         <xsl:call-template name="getNamespacePrefix"/>
       </xsl:variable>
-      
+
       <xsl:element name="{concat($nameSpacePrefix,':',local-name(.))}">
         <xsl:call-template name="add-namespaces"/>
 
@@ -224,10 +224,10 @@
         <xsl:variable name="nameSpacePrefix">
           <xsl:call-template name="getNamespacePrefix"/>
         </xsl:variable>
-        
+
         <xsl:variable name="isService"
                       select="local-name(.) = 'SV_ServiceIdentification'"/>
-      
+
         <xsl:element name="{concat($nameSpacePrefix,':',local-name(.))}">
           <xsl:apply-templates select="@*"/>
           <xsl:apply-templates select="mri:citation"/>
@@ -307,7 +307,7 @@
             <xsl:with-param name="codeListValue" select="srv2:couplingType/srv2:SV_CouplingType/@codeListValue"/>
           </xsl:call-template>
           <xsl:apply-templates select="srv2:containsOperations"/>
-          
+
           <!-- Add mandatory contains operation -->
           <xsl:if test="$isService and not(srv2:containsOperations)">
             <srv:containsOperations/>
@@ -409,7 +409,7 @@
       <!-- TODO -->
     </gmd:contentInfo>
   </xsl:template>
-  
+
   <!-- Add mandatory includedWithDataset if not present. -->
   <xsl:template match="mrc:MD_FeatureCatalogueDescription[not(mrc:includedWithDataset)]">
     <gmd:MD_FeatureCatalogueDescription>
@@ -420,7 +420,7 @@
       <xsl:apply-templates select="mrc:featureTypes|mrc:featureCatalogueCitation"/>
     </gmd:MD_FeatureCatalogueDescription>
   </xsl:template>
-  
+
   <xsl:template match="mri:associatedResource">
     <gmd:aggregationInfo>
       <gmd:MD_AggregateInformation>
@@ -434,18 +434,34 @@
     <gmd:aggregateDataSetIdentifier>
       <gmd:MD_Identifier>
         <gmd:code>
-          <gco:CharacterString><xsl:value-of select="@uuidref"/></gco:CharacterString>
+          <xsl:choose>
+            <xsl:when test="@xlink:href">
+              <gmx:Anchor>
+                <xsl:copy-of select="@xlink:*"/>
+                <xsl:value-of select="@uuidref"/>
+              </gmx:Anchor>
+            </xsl:when>
+            <xsl:otherwise>
+              <gco:CharacterString><xsl:value-of select="@uuidref"/></gco:CharacterString>
+            </xsl:otherwise>
+          </xsl:choose>
         </gmd:code>
       </gmd:MD_Identifier>
     </gmd:aggregateDataSetIdentifier>
   </xsl:template>
 
   <xsl:template match="mri:MD_AssociatedResource/mri:name" priority="2">
-    <gmd:aggregateDataSetIdentifier>
-      <gmd:MD_Identifier>
-        <xsl:apply-templates select="cit:CI_Citation/*/mcc:MD_Identifier/*"/>
-      </gmd:MD_Identifier>
-    </gmd:aggregateDataSetIdentifier>
+    <gmd:aggregateDataSetName>
+      <xsl:apply-templates select="*"/>
+    </gmd:aggregateDataSetName>
+
+    <xsl:for-each select="cit:CI_Citation/*/mcc:MD_Identifier/*">
+      <gmd:aggregateDataSetIdentifier>
+        <gmd:MD_Identifier>
+          <xsl:apply-templates select="."/>
+        </gmd:MD_Identifier>
+      </gmd:aggregateDataSetIdentifier>
+    </xsl:for-each>
 
     <!--<gmd:aggregateDataSetName>
       <xsl:apply-templates select="*"/>
@@ -462,7 +478,7 @@
   <xsl:template match="mdq:pass[gco2:Boolean = '']" priority="2">
     <gmd:pass gco:nilReason="missing"/>
   </xsl:template>
-  
+
   <xsl:template match="mdb:dataQualityInfo">
     <gmd:dataQualityInfo>
       <gmd:DQ_DataQuality>
@@ -617,7 +633,7 @@
                                     cit:ISBN|
                                     cit:ISSN|
                                     cit:onlineResource"/>
-      
+
       <!-- Special attention is required for CI_ResponsibleParties that are included in the CI_Citation only for a URL. These are currently identified as those
         with no name elements (individualName, organisationName, or positionName)
       -->
@@ -627,7 +643,7 @@
         count(cit:party/cit:CI_Organisation/cit:organisationName/gco2:CharacterString) = 0]">
         <xsl:call-template name="CI_ResponsiblePartyToOnlineResource"/>
       </xsl:for-each>
-      
+
       <xsl:apply-templates select="cit:graphic"/>
     </xsl:element>
   </xsl:template>
@@ -666,7 +682,7 @@
     <xsl:variable name="nameSpacePrefix">
       <xsl:call-template name="getNamespacePrefix"/>
     </xsl:variable>
-    
+
     <xsl:variable name="parentName"
                   select="local-name()"/>
 
@@ -677,7 +693,7 @@
       </xsl:element>
     </xsl:for-each>
   </xsl:template>
-  
+
   <xsl:template match="cit:CI_Responsibility" priority="5">
     <xsl:choose>
       <xsl:when test="count(cit:party/cit:CI_Organisation/cit:individual/cit:CI_Individual/cit:name/gco2:CharacterString) +
@@ -767,7 +783,7 @@
       <xsl:apply-templates select="*"/>
     </gmd:contactInfo>
   </xsl:template>
-  
+
   <xsl:template match="cit:contactInfo/cit:CI_Contact/cit:phone[1]">
     <!-- Only phone number and facsimile are allowed in ISO19139 -->
     <gmd:phone>


### PR DESCRIPTION
Preserve citation details and remote links details


```xml
         <mri:associatedResource>
            <mri:MD_AssociatedResource>
               <mri:name>
                  <cit:CI_Citation>
                     <cit:title xsi:type="lan:PT_FreeText_PropertyType">
                        <gco:CharacterString>Structure de la population par âge et sexe - Flandre et Région de Bruxelles-Capitale</gco:CharacterString>
                     </cit:title>
                  </cit:CI_Citation>
               </mri:name>
               <mri:associationType>
                  <mri:DS_AssociationTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_AssociationTypeCode"
                                              codeListValue="crossReference"/>
               </mri:associationType>
               <mri:metadataReference uuidref="https://www.geo.be/catalog/details/78f2e340-fe98-11eb-b8e9-7478273ff935"
                                      xlink:href="https://www.geo.be/catalog/details/78f2e340-fe98-11eb-b8e9-7478273ff935"
                                      xlink:title="Population structure by age and gender - Flanders and Brussels Capital Region"/>
            </mri:MD_AssociatedResource>
         </mri:associatedResource>
```

is mapped to

```xml
      <gmd:aggregationInfo>
        <gmd:MD_AggregateInformation>
          <gmd:aggregateDataSetName>
            <gmd:CI_Citation>
              <gmd:title>
                <gco:CharacterString>Structure de la population par âge et sexe - Flandre et Région de Bruxelles-Capitale</gco:CharacterString>
              </gmd:title>
              <gmd:date gco:nilReason="missing" />
            </gmd:CI_Citation>
          </gmd:aggregateDataSetName>
          <gmd:aggregateDataSetIdentifier>
            <gmd:MD_Identifier>
              <gmd:code>
                <gmx:Anchor xlink:href="https://www.geo.be/catalog/details/78f2e340-fe98-11eb-b8e9-7478273ff935" xlink:title="Population structure by age and gender - Flanders and Brussels Capital Region">https://www.geo.be/catalog/details/78f2e340-fe98-11eb-b8e9-7478273ff935</gmx:Anchor>
              </gmd:code>
            </gmd:MD_Identifier>
          </gmd:aggregateDataSetIdentifier>
          <gmd:associationType>
            <gmd:DS_AssociationTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_AssociationTypeCode" codeListValue="crossReference" />
          </gmd:associationType>
        </gmd:MD_AggregateInformation>
      </gmd:aggregationInfo>
```
