### PR TITLE
API / XSLT service using JSON translation may failed when : is used in key

### DIFF
--- a/services/src/main/java/org/fao/geonet/guiapi/search/XsltResponseWriter.java
+++ b/services/src/main/java/org/fao/geonet/guiapi/search/XsltResponseWriter.java
@@ -159,7 +159,7 @@ public class XsltResponseWriter {
         try {
             Map<String, String> values = mapper.readValue(jsonPath.toFile(), Map.class);
             Element element = this.xml.getChild(TRANSLATIONS);
-            values.forEach((k, v) -> element.addContent(new Element(k).setText(v)));
+            values.forEach((k, v) -> element.addContent(new Element(k.replace(":", "_")).setText(v)));
         } catch (IOException e) {
             Log.warning(Geonet.SEARCH_ENGINE, String.format(
                 "Can't find JSON file '%s'.", jsonPath.toString()


### PR DESCRIPTION

":" is invalid for XML tag name.

eg. http://localhost:8080/geonetwork/srv/api/sources can be affected