### PR TITLE
Search / Related / Missing if no id in source

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -162,7 +162,7 @@ public class EsHTTPProxy {
             related = MetadataApi.getAssociatedResources(
                 context.getLanguage(), context,
                 context.getBean(IMetadataUtils.class)
-                    .findOne(getSourceString(doc, Geonet.IndexFieldNames.ID)),
+                    .findOneByUuid(doc.get("_id").asText()),
                 relatedTypes, 0, 100);
         } catch (Exception e) {
             LOGGER.warn("Failed to load related types for {}. Error is: {}",


### PR DESCRIPTION
When a search define `source.include` with relatedType parameters, relations are always empty because the search is looking for the internal db id in the source element. Use the _id props which correspond to the UUID.

eg. this return no related object:
````
curl 'http://localhost:8080/geonetwork/srv/api/search/records/_search?relatedType=children' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'X-XSRF-TOKEN: 0097d2d2-7e44-4870-9dc2-a6c4e517a57a' \
  -H 'Accept-Language: eng' \
  -H 'Content-Type: application/json;charset=UTF-8' \
  --data-raw '{"from":0,"size":30,"sort":["_score"],"_source": {"includes": ["uuid"]}, "query":{"bool":{"must":[{"bool":{"must":[{"bool":{"should":[{"multi_match":{"query":"Contraintes liées","fields":["resourceTitleObject.default"],"type":"best_fields","operator":"or","fuzziness":0}},{"multi_match":{"query":"Contraintes liées","fields":["resourceTitleObject.default"],"type":"phrase","operator":"or"}},{"multi_match":{"query":"Contraintes liées","fields":["resourceTitleObject.default"],"type":"phrase_prefix","operator":"or"}}],"minimum_should_match":"1"}}]}}]}},"size":1,"from":0}' \
  | jq '.hits.hits[0].related'
```