### PR TITLE
Map / Feature table improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1605,7 +1605,7 @@
             var feedMdPromise =
               md && typeof md === 'object' ?
                 $q.resolve(md).then(function(md) {
-                  olL.set('md', md);
+                  olLayer.set('md', md);
                 }) : (
                   typeof md === 'string'
                     ? this.feedLayerMd(olLayer, md)

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1602,13 +1602,14 @@
             olLayer.set('name', name);
             olDecorateLayer(olLayer);
 
-            var feedMdPromise
-            if (md) {
-              feedMdPromise = $q.resolve();
-              olLayer.set('md', md);
-            } else {
-              feedMdPromise = this.feedLayerMd(olLayer);
-            }
+            var feedMdPromise =
+              md && typeof md === 'object' ?
+                $q.resolve(md).then(function(md) {
+                  olL.set('md', md);
+                }) : (
+                  typeof md === 'string'
+                    ? this.feedLayerMd(olLayer, md)
+                    : this.feedLayerMd(olLayer));
 
             // query layer info
             var layerInfoUrl = url + (url.indexOf('?') > -1 ? '&' : '?') + 'f=json';

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -655,15 +655,15 @@
           var promise;
 
           if (type === 'wmts') {
-            promise = gnMap.addWmtsFromScratch(map, res.href, name, createOnly);
+            promise = gnMap.addWmtsFromScratch(map, res.href, name, createOnly, layer.metadataUuid || null);
           } else if (type === 'arcgis') {
-            promise = gnMap.addEsriRestLayer(map, res.href, name, createOnly);
+            promise = gnMap.addEsriRestLayer(map, res.href, name, createOnly, layer.metadataUuid || null);
           }
 
           // if it's not WMTS, let's assume it is wms
           // (so as to be sure to return something)
           else {
-            promise = gnMap.addWmsFromScratch(map, res.href, name, createOnly);
+            promise = gnMap.addWmsFromScratch(map, res.href, name, createOnly, layer.metadataUuid || null);
           }
 
           return promise.then(function(olL) {

--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/WfsFilterService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/WfsFilterService.js
@@ -346,6 +346,7 @@
             if (newField.label) {
               field.label = newField.label[gnGlobalSettings.lang];
             }
+            field.definition = newField.definition;
             field.aggs = newField.aggs;
             field.display = newField.display;
             // add a flag for tokenized fields

--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
@@ -82,7 +82,8 @@
     <div data-ng-if="!managerOnly && isFeaturesIndexed"
          class="gn-facet"
          data-ng-repeat="field in fields track by field.name">
-      <h5 gn-collapsible="field.expanded">
+      <h5 gn-collapsible="field.expanded"
+          title="{{field.definition}}">
         <span class="fa fa-arrow-circle-right"
               data-ng-class="{'fa-rotate-90': field.expanded, 'gn-field-empty': !isFilterActive(field.name, field)}"></span>
         {{field.label}}


### PR DESCRIPTION
* ESRI / Add support to application/geo+json mime type which is used by ESRI server. If not, default text/xml was used but returned an ESRI response not supported by OpenLayers
* Feature table / Restore the capability to customize table column names based on feature catalogue. Add support for embedded feature catalogue in ISO19115-3 record. Add support for WFS feature indexed too and make dictionary load more consistent.
* Layer loading / Fix metadata record association for the various layer types and make more consistent calls to retrieve corresponding record for a layer.

![image](https://user-images.githubusercontent.com/1701393/159521541-b2867bf2-74be-47c4-9363-1fa0bda3b2e3.png)
