### PR TITLE
Metadata create page - allow to configure the metadata template / group to select by default (#108) - fix display title for the selected metadata

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -2034,8 +2034,6 @@
         templateUrl: '../../catalog/components/utility/' +
           'partials/metadataselector.html',
         link: function(scope, element, attrs) {
-          scope.selectedMetadata = null;
-
           scope.searchObj.params = angular.extend({},
             scope.searchObj.defaultParams);
 
@@ -2044,7 +2042,7 @@
           };
 
           scope.selectMetadata = function(md) {
-            scope.selectedMetadata = md;
+            scope.md = md;
             scope.uuid = md.uuid;
           }
 


### PR DESCRIPTION
Display of the metadata title when selecting a template was not working, displaying the old value.

![display-title-selected-metadata](https://user-images.githubusercontent.com/1695003/160371977-699e9084-af39-44d8-b64a-73f53e9311ec.png)

