### PR TITLE
Metadata detail page - sort keywords / topic categories - fix sort of  topic categories

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -175,6 +175,8 @@
 
       $scope.addToMapLayerNameUrlParam = gnGlobalSettings.gnCfg.mods.search.addWMSLayersToMap.urlLayerParam;
 
+      $scope.sortKeywordsAlphabetically = gnGlobalSettings.gnCfg.mods.recordview.sortKeywordsAlphabetically;
+
       $scope.toggleMap = function () {
         $(searchMap.getTargetElement()).toggle();
         $('button.gn-minimap-toggle > i').toggleClass('fa-angle-double-left fa-angle-double-right');


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/pull/5930, this change was missing in the repository.