### PR TITLE
Editor / Associated resources / Add missing translation for association type.

### DIFF
--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -198,8 +198,8 @@
       <util:list>
         <value>json/core+search+editor+v4+custom</value>
         <value>json/schemas</value>
-        <value>standards/iso19139/codelists/gmd:MD_TopicCategoryCode+gmd:MD_ScopeCode+gmd:MD_MaintenanceFrequencyCode+gmd:MD_ProgressCode+gmd:DS_InitiativeTypeCode+gmd:MD_SpatialRepresentationTypeCode</value>
-        <value>standards/iso19115-3.2018/codelists/cit:CI_DateTypeCode</value>
+        <value>standards/iso19139/codelists/gmd:MD_TopicCategoryCode+gmd:MD_ScopeCode+gmd:MD_MaintenanceFrequencyCode+gmd:MD_ProgressCode+gmd:MD_SpatialRepresentationTypeCode</value>
+        <value>standards/iso19115-3.2018/codelists/cit:CI_DateTypeCode+indeterminatePosition+mri:DS_InitiativeTypeCode+mri:DS_AssociationTypeCode</value>
         <value>db/MetadataCategory+Operation+Group+StatusValue+Source+Translations</value>
       </util:list>
     </entry>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -472,7 +472,7 @@
               <a target="_blank"
                  data-ng-href="{{buildMetadataLink(resource)}}">
                 {{resource.title | gnLocalized: lang}}
-                <span>{{'(' + resource.associationType + ')'}}</span>
+                <span>{{'(' + (resource.associationType | translate) + ')'}}</span>
               </a>
             </div>
             <div class="col-md-1 text-right">

--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -614,7 +614,7 @@
               var initialized = false;
               var baseList = null;
               var defaultValue;
-              var allowBlank = JSON.parse(attrs['allowBlank']) == true;
+              var allowBlank = angular.fromJson(attrs['allowBlank']) == true;
 
               var addBlankValueAndSetDefault = function() {
                 var blank = {label: '', code: ''},

--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -614,7 +614,7 @@
               var initialized = false;
               var baseList = null;
               var defaultValue;
-              var allowBlank = attrs['allowBlank'] == true;
+              var allowBlank = JSON.parse(attrs['allowBlank']) == true;
 
               var addBlankValueAndSetDefault = function() {
                 var blank = {label: '', code: ''},


### PR DESCRIPTION

Fix allow blank attribute parsing for codelist dropdown.